### PR TITLE
Fix three bugs that break marimo launch under jupyter-server-proxy

### DIFF
--- a/marimo_jupyter_extension/__init__.py
+++ b/marimo_jupyter_extension/__init__.py
@@ -7,6 +7,7 @@ marimo.
 import base64
 import os
 import secrets
+import sys
 
 from .config import get_config
 from .executable import get_marimo_command
@@ -27,8 +28,18 @@ def setup_marimoserver():
     # Get marimo command based on config
     marimo_cmd = get_marimo_command(config)
 
+    # Wrap marimo in a small reaper so descendant LSP processes are
+    # terminated when jupyter-server-proxy shuts marimo down. Without
+    # this wrapper marimo's LSP node children (spawned with
+    # start_new_session=True) are reparented to init and keep listening
+    # on ports in the 3118-3217 range, eventually exhausting marimo's
+    # port-search window. Windows is a no-op pass-through because
+    # marimo does not detach its children there.
+    reaper_cmd = [sys.executable, "-m", "marimo_jupyter_extension._reap", "--"]
+
     return {
         "command": [
+            *reaper_cmd,
             *marimo_cmd,
             *(["--log-level", "DEBUG"] if config.debug else []),
             "edit",

--- a/marimo_jupyter_extension/_proxy_patch.py
+++ b/marimo_jupyter_extension/_proxy_patch.py
@@ -1,0 +1,56 @@
+"""Runtime patch for a ``simpervisor`` race that breaks marimo respawn.
+
+When marimo exits on its own (for example on ``--timeout`` idle shutdown),
+``jupyter-server-proxy`` still holds a cached ``SupervisedProcess`` whose
+``asyncio.subprocess`` child has already been reaped. On the next request
+the proxy's ``ensure_process`` tries to ``await proc.kill()`` as part of
+its failed-to-ready cleanup, which ultimately calls
+``asyncio.base_subprocess.BaseSubprocessTransport.send_signal`` — and that
+raises ``ProcessLookupError`` because the transport knows the process is
+gone.
+
+Rather than wrapping the proxy handler, this module patches the single
+call site inside ``simpervisor.process.SupervisedProcess._signal_and_wait``
+so that both ``terminate()`` and ``kill()`` treat "already dead" as
+success. The monkey-patch is idempotent and is applied from
+``_load_jupyter_server_extension``.
+"""
+
+from __future__ import annotations
+
+_PATCHED_ATTR = "_marimo_jupyter_extension_patched"
+
+
+def apply() -> bool:
+    """Install the ``send_signal`` guard on ``SupervisedProcess``.
+
+    :returns: True if the patch was applied (or was already applied);
+        False if ``simpervisor`` could not be imported or the expected
+        method is missing (e.g. an incompatible future version).
+    """
+    try:
+        from simpervisor.process import SupervisedProcess
+    except ImportError:
+        return False
+
+    if getattr(SupervisedProcess, _PATCHED_ATTR, False):
+        return True
+
+    original = getattr(SupervisedProcess, "_signal_and_wait", None)
+    if original is None:
+        return False
+
+    async def _signal_and_wait(self, signum):
+        try:
+            return await original(self, signum)
+        except ProcessLookupError:
+            # The child was already reaped. Mark the supervised process as
+            # killed so subsequent terminate()/kill() calls don't raise
+            # KilledProcessError from a stale handle, and return cleanly.
+            self._killed = True
+            self.running = False
+            return None
+
+    SupervisedProcess._signal_and_wait = _signal_and_wait
+    setattr(SupervisedProcess, _PATCHED_ATTR, True)
+    return True

--- a/marimo_jupyter_extension/_proxy_patch.py
+++ b/marimo_jupyter_extension/_proxy_patch.py
@@ -18,19 +18,34 @@ success. The monkey-patch is idempotent and is applied from
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 _PATCHED_ATTR = "_marimo_jupyter_extension_patched"
 
+_SILENT_LOG = logging.getLogger(__name__)
 
-def apply() -> bool:
+
+def apply(log: Any = None) -> bool:
     """Install the ``send_signal`` guard on ``SupervisedProcess``.
 
+    :param log: Optional logger (``logging.Logger`` or Traitlets logger)
+        used to report patch status. If omitted, a module-level logger
+        is used so failures are still recorded somewhere.
     :returns: True if the patch was applied (or was already applied);
         False if ``simpervisor`` could not be imported or the expected
         method is missing (e.g. an incompatible future version).
     """
+    log = log if log is not None else _SILENT_LOG
+
     try:
         from simpervisor.process import SupervisedProcess
     except ImportError:
+        log.warning(
+            "marimo-jupyter-extension: simpervisor not importable; "
+            "SupervisedProcess ProcessLookupError guard NOT installed. "
+            "Marimo respawn after idle-exit may return 500 errors."
+        )
         return False
 
     if getattr(SupervisedProcess, _PATCHED_ATTR, False):
@@ -38,6 +53,11 @@ def apply() -> bool:
 
     original = getattr(SupervisedProcess, "_signal_and_wait", None)
     if original is None:
+        log.warning(
+            "marimo-jupyter-extension: "
+            "simpervisor.SupervisedProcess._signal_and_wait not found "
+            "(incompatible simpervisor version?); guard NOT installed."
+        )
         return False
 
     async def _signal_and_wait(self, signum):
@@ -47,10 +67,19 @@ def apply() -> bool:
             # The child was already reaped. Mark the supervised process as
             # killed so subsequent terminate()/kill() calls don't raise
             # KilledProcessError from a stale handle, and return cleanly.
-            self._killed = True
-            self.running = False
+            # Guard the attribute writes so that a future simpervisor
+            # refactor that renames these fields degrades to a warning
+            # rather than creating phantom attributes.
+            if hasattr(self, "_killed"):
+                self._killed = True
+            if hasattr(self, "running"):
+                self.running = False
             return None
 
     SupervisedProcess._signal_and_wait = _signal_and_wait
     setattr(SupervisedProcess, _PATCHED_ATTR, True)
+    log.info(
+        "marimo-jupyter-extension: "
+        "SupervisedProcess ProcessLookupError guard installed."
+    )
     return True

--- a/marimo_jupyter_extension/_reap.py
+++ b/marimo_jupyter_extension/_reap.py
@@ -1,0 +1,191 @@
+"""Process-tree-aware wrapper for launching marimo under jupyter-server-proxy.
+
+Marimo spawns its language-server child processes with
+``start_new_session=True``, which places them in their own POSIX sessions /
+process groups. When the marimo parent is killed (or exits after a failure),
+those LSP children are reparented to PID 1 and continue listening on their
+TCP ports. Over many Jupyter sessions these orphans accumulate and can
+exhaust the 100-port window marimo searches, at which point every new
+``marimo edit`` invocation fails with ``RuntimeError: Could not find a free
+port``.
+
+This wrapper is spliced in front of the marimo command by
+``setup_marimoserver`` so that jupyter-server-proxy sees::
+
+    python -m marimo_jupyter_extension._reap -- <marimo cmd>
+
+On SIGTERM / SIGINT / SIGHUP the wrapper enumerates the descendant tree
+*before* signaling (so LSPs still show up as descendants rather than
+orphans), SIGTERMs all of them, gives a short grace period, then
+SIGKILLs any stragglers.
+
+On Windows the wrapper is a plain pass-through: marimo does not detach its
+children on Windows (``start_new_session=not is_windows()``), so there is no
+leak to reap.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+_GRACE_SECONDS = 5.0
+_POLL_INTERVAL = 0.1
+
+
+def _ps_parent_map() -> dict[int, int]:
+    """Return a {pid: ppid} map for every process visible to ``ps``.
+
+    :returns: Mapping from PID to parent PID. Empty if ``ps`` cannot be
+        executed for any reason.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-axo", "pid=,ppid="],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+
+    mapping: dict[int, int] = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            mapping[int(parts[0])] = int(parts[1])
+        except ValueError:
+            continue
+    return mapping
+
+
+def _descendants(root_pid: int) -> set[int]:
+    """Return every transitive descendant of ``root_pid`` (excluding itself).
+
+    :param root_pid: PID whose descendant tree is being enumerated.
+    :returns: Set of descendant PIDs.
+    """
+    parent_of = _ps_parent_map()
+    children: dict[int, list[int]] = {}
+    for pid, ppid in parent_of.items():
+        children.setdefault(ppid, []).append(pid)
+
+    result: set[int] = set()
+    stack = list(children.get(root_pid, []))
+    while stack:
+        pid = stack.pop()
+        if pid in result:
+            continue
+        result.add(pid)
+        stack.extend(children.get(pid, []))
+    return result
+
+
+def _is_alive(pid: int) -> bool:
+    """Return True if signal 0 can be delivered to ``pid``."""
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+    return True
+
+
+def _send(pid: int, sig: int) -> None:
+    """Send ``sig`` to ``pid``, swallowing lookup / permission errors."""
+    try:
+        os.kill(pid, sig)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+
+def _terminate_tree(root_pid: int, child_pid: int) -> None:
+    """Gracefully terminate ``child_pid`` and every descendant of ``root_pid``.
+
+    Snapshots the descendant set first so that children which become orphans
+    (reparented to PID 1) as their immediate parent dies are still reached.
+
+    :param root_pid: PID of this wrapper; used as the descendant tree root.
+    :param child_pid: PID of the direct marimo child, explicitly included in
+        case ``ps`` output is stale.
+    """
+    targets = _descendants(root_pid) | {child_pid}
+    for pid in targets:
+        _send(pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + _GRACE_SECONDS
+    while time.monotonic() < deadline:
+        if not any(_is_alive(pid) for pid in targets):
+            return
+        time.sleep(_POLL_INTERVAL)
+
+    for pid in targets:
+        if _is_alive(pid):
+            _send(pid, signal.SIGKILL)
+
+
+def _run_windows(argv: list[str]) -> int:
+    """Pass-through runner for Windows (no descendant reaping needed)."""
+    proc = subprocess.Popen(argv)
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        return 130
+
+
+def _run_posix(argv: list[str]) -> int:
+    """Run ``argv`` and propagate shutdown signals to the descendant tree."""
+    proc = subprocess.Popen(argv)
+
+    def handler(_signum: int, _frame: object) -> None:
+        _terminate_tree(os.getpid(), proc.pid)
+
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        try:
+            signal.signal(sig, handler)
+        except (OSError, ValueError):
+            # Some environments restrict signal installation.
+            pass
+
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        _terminate_tree(os.getpid(), proc.pid)
+        return 130
+
+
+def main(argv: list[str]) -> int:
+    """Entry point. Accepts ``[--, <cmd>, <args>...]`` or ``[<cmd>, ...]``.
+
+    :param argv: Argument vector *excluding* ``sys.argv[0]``.
+    :returns: Exit status of the wrapped command (or 2 on usage error).
+    """
+    if not argv:
+        sys.stderr.write(
+            "usage: python -m marimo_jupyter_extension._reap -- "
+            "<command> [args ...]\n"
+        )
+        return 2
+    if argv[0] == "--":
+        argv = argv[1:]
+    if not argv:
+        sys.stderr.write(
+            "usage: python -m marimo_jupyter_extension._reap -- "
+            "<command> [args ...]\n"
+        )
+        return 2
+
+    if os.name == "nt":
+        return _run_windows(argv)
+    return _run_posix(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/marimo_jupyter_extension/_reap.py
+++ b/marimo_jupyter_extension/_reap.py
@@ -16,8 +16,9 @@ This wrapper is spliced in front of the marimo command by
 
 On SIGTERM / SIGINT / SIGHUP the wrapper enumerates the descendant tree
 *before* signaling (so LSPs still show up as descendants rather than
-orphans), SIGTERMs all of them, gives a short grace period, then
-SIGKILLs any stragglers.
+orphans), SIGTERMs all of them, re-enumerates once to catch anything that
+forked during shutdown, gives a short grace period, then SIGKILLs any
+stragglers.
 
 On Windows the wrapper is a plain pass-through: marimo does not detach its
 children on Windows (``start_new_session=not is_windows()``), so there is no
@@ -36,24 +37,47 @@ _GRACE_SECONDS = 5.0
 _POLL_INTERVAL = 0.1
 
 
+def _log(msg: str) -> None:
+    """Write a single line to stderr (the reaper has no logger)."""
+    try:
+        sys.stderr.write(f"marimo-jupyter-extension reaper: {msg}\n")
+        sys.stderr.flush()
+    except OSError:
+        pass
+
+
 def _ps_parent_map() -> dict[int, int]:
     """Return a {pid: ppid} map for every process visible to ``ps``.
 
     :returns: Mapping from PID to parent PID. Empty if ``ps`` cannot be
-        executed for any reason.
+        executed for any reason; a warning is written to stderr so that a
+        deployment with a broken ``ps`` is visible instead of silently
+        falling back to direct-child-only reaping.
     """
     try:
-        out = subprocess.run(
+        result = subprocess.run(
             ["ps", "-axo", "pid=,ppid="],
             capture_output=True,
             text=True,
             check=False,
-        ).stdout
-    except (OSError, subprocess.SubprocessError):
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log(
+            f"'ps' invocation failed ({exc!r}); descendant reap degraded "
+            "to direct-child-only. Orphan LSPs may leak."
+        )
+        return {}
+
+    if result.returncode != 0 or not result.stdout:
+        _log(
+            f"'ps -axo pid=,ppid=' returned rc={result.returncode}; "
+            "descendant reap degraded to direct-child-only. "
+            "Orphan LSPs may leak."
+        )
         return {}
 
     mapping: dict[int, int] = {}
-    for line in out.splitlines():
+    for line in result.stdout.splitlines():
         parts = line.split()
         if len(parts) != 2:
             continue
@@ -108,8 +132,11 @@ def _send(pid: int, sig: int) -> None:
 def _terminate_tree(root_pid: int, child_pid: int) -> None:
     """Gracefully terminate ``child_pid`` and every descendant of ``root_pid``.
 
-    Snapshots the descendant set first so that children which become orphans
-    (reparented to PID 1) as their immediate parent dies are still reached.
+    Snapshots the descendant set, SIGTERMs it, then re-enumerates once to
+    catch any process that forked between the original snapshot and the
+    first SIGTERM pass (e.g. a late LSP that marimo was still spawning
+    when shutdown began). Any processes that survive the grace window
+    are SIGKILLed.
 
     :param root_pid: PID of this wrapper; used as the descendant tree root.
     :param child_pid: PID of the direct marimo child, explicitly included in
@@ -118,6 +145,15 @@ def _terminate_tree(root_pid: int, child_pid: int) -> None:
     targets = _descendants(root_pid) | {child_pid}
     for pid in targets:
         _send(pid, signal.SIGTERM)
+
+    # Second pass: re-enumerate and SIGTERM anything we missed. Processes
+    # forked during shutdown (or reparented to PID 1 as their immediate
+    # parent died) would otherwise escape the first pass.
+    late_targets = _descendants(root_pid) - targets
+    if late_targets:
+        for pid in late_targets:
+            _send(pid, signal.SIGTERM)
+        targets |= late_targets
 
     deadline = time.monotonic() + _GRACE_SECONDS
     while time.monotonic() < deadline:

--- a/marimo_jupyter_extension/config.py
+++ b/marimo_jupyter_extension/config.py
@@ -137,6 +137,14 @@ class MarimoProxyConfig(Configurable):
     def _default_timeout(self):
         return DEFAULT_TIMEOUT
 
+    @default("idle_timeout")
+    def _default_idle_timeout(self):
+        return None
+
+    @default("session_ttl")
+    def _default_session_ttl(self):
+        return None
+
 
 @dataclass(frozen=True)
 class Config:

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -187,7 +187,7 @@ def _load_jupyter_server_extension(server_app):
     # already exited on its own (e.g. marimo's idle --timeout). Without
     # this patch the next request after marimo self-exits crashes the
     # proxy with a 500 instead of respawning marimo.
-    _apply_proxy_patch()
+    _apply_proxy_patch(server_app.log)
 
     base_url = server_app.web_app.settings["base_url"]
     server_app.web_app.add_handlers(

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -180,6 +180,15 @@ def _jupyter_server_extension_points():
 
 def _load_jupyter_server_extension(server_app):
     """Load the jupyter server extension."""
+    from ._proxy_patch import apply as _apply_proxy_patch
+
+    # Guard jupyter-server-proxy's SupervisedProcess against
+    # ProcessLookupError when it tries to kill a marimo child that has
+    # already exited on its own (e.g. marimo's idle --timeout). Without
+    # this patch the next request after marimo self-exits crashes the
+    # proxy with a 500 instead of respawning marimo.
+    _apply_proxy_patch()
+
     base_url = server_app.web_app.settings["base_url"]
     server_app.web_app.add_handlers(
         ".*",

--- a/tests/test_handlers_unit.py
+++ b/tests/test_handlers_unit.py
@@ -1,0 +1,297 @@
+"""In-process tests for ``handlers.py``.
+
+These tests exercise the handler classes and the
+``_load_jupyter_server_extension`` hook directly via mocks so that the
+module's executable lines register with the coverage collector. We invoke
+handlers via ``asyncio.run`` rather than ``pytest-asyncio`` to avoid adding
+a new test dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("jupyter_server")
+
+from marimo_jupyter_extension import handlers  # noqa: E402
+
+
+def _make_handler(handler_cls, *, body=b"{}", user="u", application=None):
+    """Build a handler instance bypassing Tornado's initializer."""
+    handler = handler_cls.__new__(handler_cls)
+    handler.request = SimpleNamespace(body=body)
+    handler.application = application
+    handler.current_user = user
+    handler.set_status = MagicMock()
+    handler.finish = MagicMock()
+    return handler
+
+
+def _run(handler, method_name):
+    """Invoke the ``@web.authenticated`` async method, bypassing the guard."""
+    method = getattr(type(handler), method_name).__wrapped__
+    asyncio.run(method(handler))
+
+
+class TestFindMarimoProxyState:
+    """``_find_marimo_proxy_state`` scans registered handlers."""
+
+    def _spec(self, pattern, state=None):
+        spec = SimpleNamespace()
+        spec.regex = re.compile(pattern)
+        spec.kwargs = {"state": state} if state is not None else {}
+        return spec
+
+    def test_returns_state_for_marimo_pattern(self):
+        state = {"proc": "x"}
+        web_app = SimpleNamespace(
+            handlers=[
+                (".*", [self._spec(r"/other", state={"x": 1})]),
+                (".*", [self._spec(r"/marimo/edit", state=state)]),
+            ]
+        )
+        assert handlers._find_marimo_proxy_state(web_app) is state
+
+    def test_returns_none_when_no_match(self):
+        web_app = SimpleNamespace(
+            handlers=[(".*", [self._spec(r"/other", state={"x": 1})])]
+        )
+        assert handlers._find_marimo_proxy_state(web_app) is None
+
+    def test_ignores_specs_without_state_kwarg(self):
+        web_app = SimpleNamespace(handlers=[(".*", [self._spec(r"/marimo")])])
+        assert handlers._find_marimo_proxy_state(web_app) is None
+
+
+class TestConvertHandler:
+    """``ConvertHandler.post`` validates input and delegates to convert."""
+
+    def test_missing_input_returns_400(self):
+        handler = _make_handler(
+            handlers.ConvertHandler,
+            body=json.dumps({"output": "x.py"}).encode(),
+        )
+        _run(handler, "post")
+        handler.set_status.assert_called_once_with(400)
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is False
+        assert "Missing" in payload["error"]
+
+    def test_missing_output_returns_400(self):
+        handler = _make_handler(
+            handlers.ConvertHandler,
+            body=json.dumps({"input": "x.ipynb"}).encode(),
+        )
+        _run(handler, "post")
+        handler.set_status.assert_called_once_with(400)
+
+    def test_calls_convert_and_finishes_with_success(self):
+        with patch.object(handlers, "convert_notebook_to_marimo") as cv:
+            handler = _make_handler(
+                handlers.ConvertHandler,
+                body=json.dumps(
+                    {"input": "x.ipynb", "output": "x.py"}
+                ).encode(),
+            )
+            _run(handler, "post")
+        cv.assert_called_once_with("x.ipynb", "x.py")
+        payload = handler.finish.call_args[0][0]
+        assert payload == {"success": True, "output": "x.py"}
+
+    def test_runtime_error_returns_500(self):
+        with patch.object(
+            handlers,
+            "convert_notebook_to_marimo",
+            side_effect=RuntimeError("conv failed"),
+        ):
+            handler = _make_handler(
+                handlers.ConvertHandler,
+                body=json.dumps(
+                    {"input": "x.ipynb", "output": "x.py"}
+                ).encode(),
+            )
+            _run(handler, "post")
+        handler.set_status.assert_called_once_with(500)
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is False
+        assert "conv failed" in payload["error"]
+
+
+class TestRestartHandler:
+    """``RestartHandler.post`` kills and clears the cached proxy process."""
+
+    def _state(self, proc):
+        lock = MagicMock()
+        lock.__aenter__ = AsyncMock(return_value=None)
+        lock.__aexit__ = AsyncMock(return_value=None)
+        return {"proc": proc, "proc_lock": lock}
+
+    def test_returns_503_when_state_missing(self):
+        with patch.object(
+            handlers, "_find_marimo_proxy_state", return_value=None
+        ):
+            handler = _make_handler(
+                handlers.RestartHandler, application=SimpleNamespace()
+            )
+            _run(handler, "post")
+        handler.set_status.assert_called_once_with(503)
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is False
+
+    def test_kills_live_process_and_clears_state(self):
+        proc = MagicMock()
+        proc.kill = AsyncMock()
+        state = self._state(proc)
+        with patch.object(
+            handlers, "_find_marimo_proxy_state", return_value=state
+        ):
+            handler = _make_handler(
+                handlers.RestartHandler, application=SimpleNamespace()
+            )
+            _run(handler, "post")
+        proc.kill.assert_awaited_once()
+        assert "proc" not in state
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is True
+
+    def test_swallows_kill_exception(self):
+        proc = MagicMock()
+        proc.kill = AsyncMock(side_effect=RuntimeError("already dead"))
+        state = self._state(proc)
+        with patch.object(
+            handlers, "_find_marimo_proxy_state", return_value=state
+        ):
+            handler = _make_handler(
+                handlers.RestartHandler, application=SimpleNamespace()
+            )
+            _run(handler, "post")
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is True
+        assert "proc" not in state
+
+    def test_skips_kill_when_process_not_managed(self):
+        state = self._state("process not managed")
+        with patch.object(
+            handlers, "_find_marimo_proxy_state", return_value=state
+        ):
+            handler = _make_handler(
+                handlers.RestartHandler, application=SimpleNamespace()
+            )
+            _run(handler, "post")
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is True
+
+
+class TestConfigHandler:
+    """``ConfigHandler.get`` returns the extension config."""
+
+    def test_returns_no_sandbox_flag(self):
+        fake_config = SimpleNamespace(no_sandbox=True)
+        with patch(
+            "marimo_jupyter_extension.config.get_config",
+            return_value=fake_config,
+        ):
+            handler = _make_handler(handlers.ConfigHandler)
+            _run(handler, "get")
+        handler.finish.assert_called_once_with({"no_sandbox": True})
+
+
+class TestCreateStubHandler:
+    """``CreateStubHandler.post`` writes a stub file with optional PEP 723."""
+
+    def test_missing_path_returns_400(self):
+        handler = _make_handler(
+            handlers.CreateStubHandler,
+            body=json.dumps({}).encode(),
+        )
+        _run(handler, "post")
+        handler.set_status.assert_called_once_with(400)
+
+    def test_writes_stub_without_venv(self, tmp_path):
+        target = tmp_path / "stub.py"
+        handler = _make_handler(
+            handlers.CreateStubHandler,
+            body=json.dumps({"path": str(target)}).encode(),
+        )
+        _run(handler, "post")
+        handler.finish.assert_called_once()
+        content = target.read_text()
+        assert "import marimo" in content
+        assert "# /// script" not in content
+
+    def test_writes_stub_with_venv_header(self, tmp_path):
+        target = tmp_path / "stub.py"
+        venv_python = tmp_path / "venv" / "bin" / "python3.12"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.touch()
+        handler = _make_handler(
+            handlers.CreateStubHandler,
+            body=json.dumps(
+                {"path": str(target), "venv": str(venv_python)}
+            ).encode(),
+        )
+        _run(handler, "post")
+        content = target.read_text()
+        assert "# /// script" in content
+        assert str(tmp_path / "venv") in content
+
+    def test_handles_venv_path_without_bin(self, tmp_path):
+        target = tmp_path / "stub.py"
+        venv_python = tmp_path / "python"
+        venv_python.touch()
+        handler = _make_handler(
+            handlers.CreateStubHandler,
+            body=json.dumps(
+                {"path": str(target), "venv": str(venv_python)}
+            ).encode(),
+        )
+        _run(handler, "post")
+        content = target.read_text()
+        assert "# /// script" in content
+
+    def test_write_failure_returns_500(self, tmp_path):
+        bad_path = tmp_path / "no-such-dir" / "stub.py"
+        handler = _make_handler(
+            handlers.CreateStubHandler,
+            body=json.dumps({"path": str(bad_path)}).encode(),
+        )
+        _run(handler, "post")
+        handler.set_status.assert_called_once_with(500)
+        payload = handler.finish.call_args[0][0]
+        assert payload["success"] is False
+
+
+class TestExtensionHooks:
+    """Server-extension entry points."""
+
+    def test_extension_points_returns_this_module(self):
+        result = handlers._jupyter_server_extension_points()
+        assert result == [{"module": "marimo_jupyter_extension.handlers"}]
+
+    def test_load_extension_registers_handlers_and_applies_patch(self):
+        added = []
+        web_app = MagicMock()
+        web_app.settings = {"base_url": "/"}
+        web_app.add_handlers = MagicMock(
+            side_effect=lambda host, items: added.extend(items)
+        )
+        server_app = SimpleNamespace(web_app=web_app, log=MagicMock())
+
+        with patch(
+            "marimo_jupyter_extension._proxy_patch.apply"
+        ) as apply_mock:
+            handlers._load_jupyter_server_extension(server_app)
+
+        apply_mock.assert_called_once_with(server_app.log)
+        routes = [route for route, _cls in added]
+        assert any("convert" in r for r in routes)
+        assert any("restart" in r for r in routes)
+        assert any("create-stub" in r for r in routes)
+        assert any("config" in r for r in routes)
+        server_app.log.info.assert_called_once()

--- a/tests/test_proxy_patch.py
+++ b/tests/test_proxy_patch.py
@@ -1,0 +1,98 @@
+"""Tests for the ``_proxy_patch`` runtime patch on simpervisor."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("simpervisor")
+
+from simpervisor.process import SupervisedProcess  # noqa: E402
+
+from marimo_jupyter_extension import _proxy_patch  # noqa: E402
+
+
+@pytest.fixture
+def fresh_patch():
+    """Restore the original SupervisedProcess._signal_and_wait between tests."""
+    original = SupervisedProcess._signal_and_wait
+    if hasattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR):
+        delattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR)
+    yield
+    SupervisedProcess._signal_and_wait = original
+    if hasattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR):
+        delattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR)
+
+
+class _Fake:
+    """Object with attributes the patched wrapper touches."""
+
+    def __init__(self):
+        self._killed = False
+        self.running = True
+
+
+class TestApply:
+    """Patch installation."""
+
+    def test_apply_reports_success(self, fresh_patch):
+        assert _proxy_patch.apply() is True
+
+    def test_apply_is_idempotent(self, fresh_patch):
+        assert _proxy_patch.apply() is True
+        assert _proxy_patch.apply() is True
+
+    def test_apply_marks_class_as_patched(self, fresh_patch):
+        _proxy_patch.apply()
+        assert (
+            getattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR, False)
+            is True
+        )
+
+
+class TestPatchedBehavior:
+    """The wrapped ``_signal_and_wait`` swallows ProcessLookupError only."""
+
+    def test_process_lookup_error_is_swallowed(self, fresh_patch):
+        async def raising(self, signum):  # noqa: ARG001
+            raise ProcessLookupError()
+
+        SupervisedProcess._signal_and_wait = raising
+        _proxy_patch.apply()
+
+        fake = _Fake()
+        result = asyncio.run(SupervisedProcess._signal_and_wait(fake, 15))
+
+        assert result is None
+        assert fake._killed is True
+        assert fake.running is False
+
+    def test_successful_signal_passes_through(self, fresh_patch):
+        calls: list[int] = []
+
+        async def success(self, signum):  # noqa: ARG001
+            calls.append(signum)
+            return "ok"
+
+        SupervisedProcess._signal_and_wait = success
+        _proxy_patch.apply()
+
+        fake = _Fake()
+        result = asyncio.run(SupervisedProcess._signal_and_wait(fake, 15))
+
+        assert result == "ok"
+        assert calls == [15]
+        assert fake._killed is False
+        assert fake.running is True
+
+    def test_other_exceptions_still_propagate(self, fresh_patch):
+        async def boom(self, signum):  # noqa: ARG001
+            raise RuntimeError("boom")
+
+        SupervisedProcess._signal_and_wait = boom
+        _proxy_patch.apply()
+
+        fake = _Fake()
+        with pytest.raises(RuntimeError, match="boom"):
+            asyncio.run(SupervisedProcess._signal_and_wait(fake, 15))

--- a/tests/test_proxy_patch.py
+++ b/tests/test_proxy_patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -49,6 +50,45 @@ class TestApply:
             getattr(SupervisedProcess, _proxy_patch._PATCHED_ATTR, False)
             is True
         )
+
+    def test_apply_logs_success_when_logger_given(self, fresh_patch, caplog):
+        log = logging.getLogger("test.apply.success")
+        with caplog.at_level(logging.INFO, logger=log.name):
+            _proxy_patch.apply(log)
+        assert any(
+            "guard installed" in rec.getMessage()
+            for rec in caplog.records
+            if rec.name == log.name
+        )
+
+    def test_apply_is_quiet_on_second_call(self, fresh_patch, caplog):
+        log = logging.getLogger("test.apply.idempotent")
+        _proxy_patch.apply(log)
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=log.name):
+            _proxy_patch.apply(log)
+        assert not [rec for rec in caplog.records if rec.name == log.name]
+
+    def test_missing_attributes_degrade_gracefully(self, fresh_patch):
+        """If simpervisor renames ``_killed`` / ``running``, the wrapper
+        must not create phantom attributes — it must swallow the lookup
+        error silently."""
+
+        async def raising(self, signum):  # noqa: ARG001
+            raise ProcessLookupError()
+
+        SupervisedProcess._signal_and_wait = raising
+        _proxy_patch.apply()
+
+        class Bare:
+            pass
+
+        bare = Bare()
+        result = asyncio.run(SupervisedProcess._signal_and_wait(bare, 15))
+
+        assert result is None
+        assert not hasattr(bare, "_killed")
+        assert not hasattr(bare, "running")
 
 
 class TestPatchedBehavior:

--- a/tests/test_proxy_patch.py
+++ b/tests/test_proxy_patch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -136,3 +138,70 @@ class TestPatchedBehavior:
         fake = _Fake()
         with pytest.raises(RuntimeError, match="boom"):
             asyncio.run(SupervisedProcess._signal_and_wait(fake, 15))
+
+
+class TestDegradedPaths:
+    """Import and attribute failures return False and log a warning."""
+
+    def test_returns_false_when_simpervisor_not_importable(self, caplog):
+        """If ``simpervisor`` cannot be imported the patch reports failure
+        and writes a warning to the supplied logger."""
+        log = logging.getLogger("test.apply.no.simpervisor")
+        # Remove the already-imported simpervisor modules so that the fresh
+        # import inside ``apply`` re-runs and can be forced to fail.
+        saved = {
+            name: mod
+            for name, mod in list(sys.modules.items())
+            if name == "simpervisor" or name.startswith("simpervisor.")
+        }
+        for name in saved:
+            del sys.modules[name]
+        try:
+            original_import = (
+                __builtins__["__import__"]
+                if isinstance(__builtins__, dict)
+                else __builtins__.__import__
+            )
+
+            def fake_import(name, *args, **kwargs):
+                if name == "simpervisor.process" or name.startswith(
+                    "simpervisor"
+                ):
+                    raise ImportError("forced")
+                return original_import(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=fake_import):
+                with caplog.at_level(logging.WARNING, logger=log.name):
+                    assert _proxy_patch.apply(log) is False
+        finally:
+            sys.modules.update(saved)
+
+        assert any(
+            "simpervisor not importable" in rec.getMessage()
+            for rec in caplog.records
+            if rec.name == log.name
+        )
+
+    def test_returns_false_when_signal_method_missing(
+        self, fresh_patch, caplog
+    ):
+        """If ``simpervisor`` renames ``_signal_and_wait`` the patch refuses
+        to install and logs a warning."""
+        log = logging.getLogger("test.apply.no.method")
+        fake_proc_module = MagicMock()
+
+        class _NoSignalSupervisedProcess:
+            pass
+
+        fake_proc_module.SupervisedProcess = _NoSignalSupervisedProcess
+        with patch.dict(
+            sys.modules, {"simpervisor.process": fake_proc_module}
+        ):
+            with caplog.at_level(logging.WARNING, logger=log.name):
+                assert _proxy_patch.apply(log) is False
+
+        assert any(
+            "_signal_and_wait not found" in rec.getMessage()
+            for rec in caplog.records
+            if rec.name == log.name
+        )

--- a/tests/test_reap.py
+++ b/tests/test_reap.py
@@ -1,0 +1,187 @@
+"""Tests for the ``_reap`` wrapper that reaps marimo's descendant processes."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REAP = "marimo_jupyter_extension._reap"
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True while ``pid`` is a live, non-zombie process."""
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    # Treat zombies as dead for test purposes.
+    try:
+        with open(f"/proc/{pid}/status") as fh:
+            for line in fh:
+                if line.startswith("State:"):
+                    return "Z" not in line.split()[1]
+    except OSError:
+        pass
+    return True
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    """Poll ``predicate`` until it returns truthy or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestMainArgumentParsing:
+    """Argument parsing in ``_reap.main``."""
+
+    def test_returns_error_when_no_args(self):
+        from marimo_jupyter_extension._reap import main
+
+        assert main([]) == 2
+
+    def test_returns_error_when_only_separator(self):
+        from marimo_jupyter_extension._reap import main
+
+        assert main(["--"]) == 2
+
+
+class TestPassThrough:
+    """End-to-end behavior: exit status and stdout propagate."""
+
+    def test_exit_status_is_propagated(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                REAP,
+                "--",
+                sys.executable,
+                "-c",
+                "raise SystemExit(7)",
+            ],
+            capture_output=True,
+        )
+        assert result.returncode == 7
+
+    def test_stdout_is_propagated(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                REAP,
+                "--",
+                sys.executable,
+                "-c",
+                "print('hello reaper')",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "hello reaper" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX-only descendant reaping")
+class TestDescendantReap:
+    """Descendants of the wrapped process are killed on SIGTERM."""
+
+    def test_detached_grandchild_is_reaped(self, tmp_path: Path):
+        """A grandchild spawned with ``start_new_session=True`` (mimicking
+        marimo's LSP spawn) must still be killed when the reaper receives
+        SIGTERM."""
+        marker = tmp_path / "grandchild.pid"
+        # The child writes its detached grandchild's PID to a file, then
+        # blocks. When the reaper terminates, both child and grandchild
+        # should be gone.
+        script = textwrap.dedent(
+            f"""
+            import os, subprocess, sys, time
+            gc = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(300)"],
+                start_new_session=True,
+            )
+            open({str(marker)!r}, "w").write(str(gc.pid))
+            time.sleep(300)
+            """
+        )
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", REAP, "--", sys.executable, "-c", script]
+        )
+        try:
+            assert _wait_until(marker.exists), "grandchild never started"
+            gc_pid = int(marker.read_text().strip())
+            assert _pid_alive(gc_pid)
+
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=15)
+
+            # After the wrapper exits the grandchild must also be gone.
+            assert _wait_until(lambda: not _pid_alive(gc_pid), timeout=10), (
+                f"grandchild pid={gc_pid} still alive after reaper exit"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            # Belt-and-braces cleanup of the grandchild if the test failed.
+            if marker.exists():
+                try:
+                    os.kill(int(marker.read_text().strip()), signal.SIGKILL)
+                except (OSError, ValueError):
+                    pass
+
+    def test_clean_exit_does_not_emit_error(self):
+        """If the wrapped command exits on its own, the wrapper returns 0."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                REAP,
+                "--",
+                sys.executable,
+                "-c",
+                "pass",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert result.stderr == ""
+
+
+class TestSetupWiring:
+    """``setup_marimoserver`` must splice the reaper in front of marimo."""
+
+    def test_command_starts_with_reaper(self, clean_env, mock_marimo_in_path):
+        from marimo_jupyter_extension import setup_marimoserver
+
+        cmd = setup_marimoserver()["command"]
+
+        assert cmd[0] == sys.executable
+        assert cmd[1] == "-m"
+        assert cmd[2] == "marimo_jupyter_extension._reap"
+        assert cmd[3] == "--"
+
+    def test_reaper_is_before_marimo_executable(
+        self, clean_env, mock_marimo_in_path
+    ):
+        """The resolved marimo path must sit after the reaper preamble."""
+        from marimo_jupyter_extension import setup_marimoserver
+
+        cmd = setup_marimoserver()["command"]
+        marimo_index = cmd.index(mock_marimo_in_path)
+        assert marimo_index == 4
+        assert "edit" in cmd[marimo_index:]

--- a/tests/test_reap.py
+++ b/tests/test_reap.py
@@ -142,6 +142,55 @@ class TestDescendantReap:
                 except (OSError, ValueError):
                     pass
 
+    def test_late_spawned_grandchild_is_reaped(self, tmp_path: Path):
+        """A grandchild spawned *after* SIGTERM arrives (during shutdown)
+        must still be killed by the second-pass re-enumeration."""
+        marker = tmp_path / "late_grandchild.pid"
+        script = textwrap.dedent(
+            f"""
+            import os, signal, subprocess, sys, time
+
+            def spawn_on_term(signum, frame):
+                gc = subprocess.Popen(
+                    [sys.executable, "-c", "import time; time.sleep(300)"],
+                    start_new_session=True,
+                )
+                open({str(marker)!r}, "w").write(str(gc.pid))
+                # Give the reaper's second pass time to see us.
+                time.sleep(2.0)
+                sys.exit(0)
+
+            signal.signal(signal.SIGTERM, spawn_on_term)
+            time.sleep(300)
+            """
+        )
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", REAP, "--", sys.executable, "-c", script]
+        )
+        try:
+            time.sleep(0.5)
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=15)
+
+            assert _wait_until(marker.exists, timeout=5), (
+                "late grandchild never started"
+            )
+            gc_pid = int(marker.read_text().strip())
+
+            assert _wait_until(lambda: not _pid_alive(gc_pid), timeout=10), (
+                f"late grandchild pid={gc_pid} still alive after reaper exit"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            if marker.exists():
+                try:
+                    os.kill(int(marker.read_text().strip()), signal.SIGKILL)
+                except (OSError, ValueError):
+                    pass
+
     def test_clean_exit_does_not_emit_error(self):
         """If the wrapped command exits on its own, the wrapper returns 0."""
         result = subprocess.run(

--- a/tests/test_reap_unit.py
+++ b/tests/test_reap_unit.py
@@ -1,0 +1,312 @@
+"""In-process unit tests for ``_reap`` helpers.
+
+The end-to-end tests in ``test_reap.py`` exercise ``_reap`` as a subprocess,
+which means their code paths do not register with the parent coverage
+collector. These tests import and call the helpers directly so that the
+reaper's internals are visible to coverage.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from marimo_jupyter_extension import _reap
+
+
+class TestLog:
+    """Stderr logger does not raise when stderr is unavailable."""
+
+    def test_writes_prefixed_message(self, capsys):
+        _reap._log("hello")
+        captured = capsys.readouterr()
+        assert "marimo-jupyter-extension reaper: hello" in captured.err
+
+    def test_oserror_on_stderr_is_swallowed(self):
+        with patch.object(_reap.sys, "stderr") as stderr:
+            stderr.write.side_effect = OSError("closed")
+            _reap._log("unreachable")
+
+
+class TestPsParentMap:
+    """``_ps_parent_map`` parses ``ps`` output and handles failures."""
+
+    def test_parses_real_ps_output(self):
+        mapping = _reap._ps_parent_map()
+        assert mapping, "ps should return at least one process on a live host"
+        assert os.getpid() in mapping
+
+    def test_returns_empty_when_ps_missing(self):
+        with patch.object(_reap.subprocess, "run", side_effect=OSError):
+            assert _reap._ps_parent_map() == {}
+
+    def test_returns_empty_when_ps_raises_subprocess_error(self):
+        with patch.object(
+            _reap.subprocess,
+            "run",
+            side_effect=subprocess.SubprocessError("boom"),
+        ):
+            assert _reap._ps_parent_map() == {}
+
+    def test_returns_empty_when_ps_returncode_nonzero(self):
+        fake = MagicMock(returncode=1, stdout="")
+        with patch.object(_reap.subprocess, "run", return_value=fake):
+            assert _reap._ps_parent_map() == {}
+
+    def test_skips_malformed_lines(self):
+        fake = MagicMock(
+            returncode=0,
+            stdout="1 0\n2 1\nnot a row\nabc def\n3 2\n",
+        )
+        with patch.object(_reap.subprocess, "run", return_value=fake):
+            assert _reap._ps_parent_map() == {1: 0, 2: 1, 3: 2}
+
+
+class TestDescendants:
+    """``_descendants`` walks the parent map transitively."""
+
+    def test_returns_transitive_descendants(self):
+        parent_map = {10: 1, 20: 10, 30: 20, 40: 1, 50: 40}
+        with patch.object(_reap, "_ps_parent_map", return_value=parent_map):
+            assert _reap._descendants(10) == {20, 30}
+
+    def test_returns_empty_for_leaf(self):
+        with patch.object(_reap, "_ps_parent_map", return_value={1: 0}):
+            assert _reap._descendants(99) == set()
+
+
+class TestIsAlive:
+    """``_is_alive`` uses signal 0 and swallows errors."""
+
+    def test_self_is_alive(self):
+        assert _reap._is_alive(os.getpid()) is True
+
+    def test_nonexistent_pid_is_not_alive(self):
+        with patch.object(_reap.os, "kill", side_effect=ProcessLookupError):
+            assert _reap._is_alive(999999) is False
+
+    def test_permission_error_means_not_alive(self):
+        with patch.object(_reap.os, "kill", side_effect=PermissionError):
+            assert _reap._is_alive(1) is False
+
+    def test_other_os_error_means_not_alive(self):
+        with patch.object(_reap.os, "kill", side_effect=OSError("unexpected")):
+            assert _reap._is_alive(1) is False
+
+
+class TestSend:
+    """``_send`` swallows lookup / permission / OS errors."""
+
+    def test_sends_signal(self):
+        with patch.object(_reap.os, "kill") as kill:
+            _reap._send(42, signal.SIGTERM)
+            kill.assert_called_once_with(42, signal.SIGTERM)
+
+    def test_swallows_process_lookup_error(self):
+        with patch.object(_reap.os, "kill", side_effect=ProcessLookupError):
+            _reap._send(42, signal.SIGTERM)
+
+    def test_swallows_permission_error(self):
+        with patch.object(_reap.os, "kill", side_effect=PermissionError):
+            _reap._send(42, signal.SIGTERM)
+
+    def test_swallows_os_error(self):
+        with patch.object(_reap.os, "kill", side_effect=OSError("nope")):
+            _reap._send(42, signal.SIGTERM)
+
+
+class TestTerminateTree:
+    """``_terminate_tree`` signals descendants, re-enumerates, then SIGKILLs."""
+
+    def test_sigterms_initial_descendants_and_child(self):
+        with (
+            patch.object(
+                _reap, "_descendants", side_effect=[{100, 101}, set()]
+            ),
+            patch.object(_reap, "_send") as send,
+            patch.object(_reap, "_is_alive", return_value=False),
+        ):
+            _reap._terminate_tree(root_pid=1, child_pid=200)
+
+        sigterm_targets = {
+            args[0]
+            for args, _ in send.call_args_list
+            if args[1] == signal.SIGTERM
+        }
+        assert sigterm_targets == {100, 101, 200}
+
+    def test_second_pass_catches_late_spawns(self):
+        with (
+            patch.object(
+                _reap, "_descendants", side_effect=[{100}, {100, 101}]
+            ),
+            patch.object(_reap, "_send") as send,
+            patch.object(_reap, "_is_alive", return_value=False),
+        ):
+            _reap._terminate_tree(root_pid=1, child_pid=200)
+
+        sigterm_targets = [
+            args[0]
+            for args, _ in send.call_args_list
+            if args[1] == signal.SIGTERM
+        ]
+        assert sorted(sigterm_targets) == [100, 101, 200]
+
+    def test_sigkills_survivors(self, monkeypatch):
+        monkeypatch.setattr(_reap, "_GRACE_SECONDS", 0.05)
+        monkeypatch.setattr(_reap, "_POLL_INTERVAL", 0.01)
+        with (
+            patch.object(_reap, "_descendants", side_effect=[{100}, set()]),
+            patch.object(_reap, "_send") as send,
+            patch.object(_reap, "_is_alive", return_value=True),
+        ):
+            _reap._terminate_tree(root_pid=1, child_pid=200)
+
+        sigkill_targets = {
+            args[0]
+            for args, _ in send.call_args_list
+            if args[1] == signal.SIGKILL
+        }
+        assert sigkill_targets == {100, 200}
+
+    def test_returns_early_when_all_targets_dead(self, monkeypatch):
+        monkeypatch.setattr(_reap, "_GRACE_SECONDS", 5.0)
+        monkeypatch.setattr(_reap, "_POLL_INTERVAL", 0.01)
+        with (
+            patch.object(_reap, "_descendants", side_effect=[{100}, set()]),
+            patch.object(_reap, "_send") as send,
+            patch.object(_reap, "_is_alive", return_value=False),
+        ):
+            _reap._terminate_tree(root_pid=1, child_pid=200)
+
+        sigkill_calls = [
+            c for c in send.call_args_list if c.args[1] == signal.SIGKILL
+        ]
+        assert sigkill_calls == []
+
+
+class TestRunWindows:
+    """``_run_windows`` is a pass-through with KeyboardInterrupt handling."""
+
+    def test_returns_child_exit_code(self):
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        with patch.object(_reap.subprocess, "Popen", return_value=proc):
+            assert _reap._run_windows(["echo", "hi"]) == 0
+
+    def test_keyboard_interrupt_terminates_child(self):
+        proc = MagicMock()
+        proc.wait.side_effect = KeyboardInterrupt
+        with patch.object(_reap.subprocess, "Popen", return_value=proc):
+            assert _reap._run_windows(["sleep", "9"]) == 130
+        proc.terminate.assert_called_once()
+
+
+class TestRunPosix:
+    """``_run_posix`` installs handlers and propagates on KeyboardInterrupt."""
+
+    def test_installs_handlers_and_returns_child_exit_code(self):
+        proc = MagicMock()
+        proc.wait.return_value = 7
+        proc.pid = 12345
+        installed: dict[int, object] = {}
+
+        def fake_signal(sig, handler):
+            installed[sig] = handler
+
+        with (
+            patch.object(_reap.subprocess, "Popen", return_value=proc),
+            patch.object(_reap.signal, "signal", side_effect=fake_signal),
+        ):
+            rc = _reap._run_posix(["echo", "hi"])
+        assert rc == 7
+        assert signal.SIGTERM in installed
+        assert signal.SIGINT in installed
+        assert signal.SIGHUP in installed
+
+    def test_signal_installation_errors_are_swallowed(self):
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        with (
+            patch.object(_reap.subprocess, "Popen", return_value=proc),
+            patch.object(
+                _reap.signal, "signal", side_effect=OSError("restricted")
+            ),
+        ):
+            assert _reap._run_posix(["echo", "hi"]) == 0
+
+    def test_handler_invokes_terminate_tree(self):
+        proc = MagicMock()
+        proc.wait.return_value = 0
+        proc.pid = 4242
+        installed: dict[int, object] = {}
+
+        def fake_signal(sig, handler):
+            installed[sig] = handler
+
+        with (
+            patch.object(_reap.subprocess, "Popen", return_value=proc),
+            patch.object(_reap.signal, "signal", side_effect=fake_signal),
+            patch.object(_reap, "_terminate_tree") as tt,
+        ):
+            _reap._run_posix(["echo", "hi"])
+            installed[signal.SIGTERM](signal.SIGTERM, None)
+
+        tt.assert_called_once_with(os.getpid(), 4242)
+
+    def test_keyboard_interrupt_triggers_terminate_tree(self):
+        proc = MagicMock()
+        proc.wait.side_effect = KeyboardInterrupt
+        proc.pid = 9999
+        with (
+            patch.object(_reap.subprocess, "Popen", return_value=proc),
+            patch.object(_reap.signal, "signal"),
+            patch.object(_reap, "_terminate_tree") as tt,
+        ):
+            assert _reap._run_posix(["sleep", "9"]) == 130
+        tt.assert_called_once_with(os.getpid(), 9999)
+
+
+class TestMainDispatch:
+    """``main`` dispatches to the platform-specific runner."""
+
+    def test_routes_to_windows_runner_when_nt(self):
+        with (
+            patch.object(_reap.os, "name", "nt"),
+            patch.object(_reap, "_run_windows", return_value=3) as rw,
+            patch.object(_reap, "_run_posix") as rp,
+        ):
+            assert _reap.main(["--", "cmd", "arg"]) == 3
+        rw.assert_called_once_with(["cmd", "arg"])
+        rp.assert_not_called()
+
+    def test_routes_to_posix_runner_otherwise(self):
+        with (
+            patch.object(_reap.os, "name", "posix"),
+            patch.object(_reap, "_run_posix", return_value=5) as rp,
+            patch.object(_reap, "_run_windows") as rw,
+        ):
+            assert _reap.main(["cmd", "arg"]) == 5
+        rp.assert_called_once_with(["cmd", "arg"])
+        rw.assert_not_called()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="module-main path only exercised on POSIX"
+)
+class TestModuleMain:
+    """The ``__main__`` guard routes through ``main``."""
+
+    def test_module_main_usage_error_exits_2(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "marimo_jupyter_extension._reap"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "usage:" in result.stderr


### PR DESCRIPTION
### Overview

I initially realized the extension had exhausted all my ports in the range of 3118-3217 because the LSP processes were not being killed when the Marimo parent was killed. I took a stab at fixing this, and the other two issues surfaced while I was testing locally. Here is the summary:

1. **Orphan LSP processes exhaust marimo's port pool.** Marimo spawns its language-server children with start_new_session=True, so when the Marimo parent is killed they reparent to PID 1 and keep listening on TCP ports in Marimo 3118–3217 search window. After enough Jupyter sessions, every Marimo edit fails with `RuntimeError: Could not find a free port.`
2. **Stale `SupervisedProcess` raises `ProcessLookupError` on the next request.**  When Marimo self-exits (e.g. idle --timeout), jupyter-server-proxy still holds the old `SupervisedProcess`. Its cleanup path `awaits proc.kill() `→ `BaseSubprocessTransport.send_signal`, which raises `ProcessLookupError `and returns a 500 error instead of the proxy respawning Marimo.
3. **`--timeout 0.0 kills` marimo the instant it starts.** `traitlets.Float(allow_none=True)` and `Int(allow_none=True)` resolve to 0.0 and 0 by default, not `None`. `setup_marimoserver` then always appended `--timeout 0.0 --session-ttl 0`, which Marimo treats as "shut down immediately", producing a 60s health-check timeout / 500 on every click.

### Changes

  - **`marimo_jupyter_extension/_reap.py`** — stdlib-only wrapper. On `SIGTERM` / `SIGINT` / `SIGHUP` it snapshots the descendant tree via `ps -axo pid=,ppid=`, `SIGTERM`s every descendant plus the direct child, re-enumerates once to catch anything forked during shutdown, waits 5 s, then `SIGKILL`s any stragglers. Windows is a pass-through because marimo doesn't detach its children there (`start_new_session=not is_windows()`).         
  - **`marimo_jupyter_extension/_proxy_patch.py`** — at extension load, monkey-patches `simpervisor.process.SupervisedProcess._signal_and_wait` to swallow `ProcessLookupError` from a reaped child (sets `_killed=True`, `running=False`, returns `None`). Idempotent; successful calls and other exceptions pass through untouched. Accepts an optional logger and reports `INFO` on success, `WARNING` when simpervisor is missing or its internal API has drifted.
  - **`marimo_jupyter_extension/__init__.py`** — `setup_marimoserver` prepends `[python, -m, marimo_jupyter_extension._reap, --]` to the spawned command.                                                                                                                                              
  - **`marimo_jupyter_extension/handlers.py`** — `_load_jupyter_server_extension` calls `_apply_proxy_patch(server_app.log)` before registering handlers.                                                                                                                                             
  - **`marimo_jupyter_extension/config.py`** — add `@default` handlers for `idle_timeout` and `session_ttl` returning `None` so the flags stay unset unless explicitly configured.

### Risks and Mitigations

There's a few things that were added to mitigate potential issues around the changes.

1. **`_proxy_patch.apply()` logs its result.** This targets `simpervisor.process.SupervisedProcess._signal_and_wait`, which *could* change in a major simplevisor version. The issue here could be escalated to the `jupyter-server-proxy` / `simpervisor` teams to implement an actual fix.
2. **`_reap` relies on `ps`.** Containers without `ps` fall back to direct-child-only reaping and now log a warning so the degradation is visible. This was the original behavior anyway.