### PR TITLE
fix: check for process to stop deadlock on polling

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ On JupyterHub deployments, this leverages existing authentication and spawning i
 ## Quick Start
 
 ```bash
-pip install 'marimo>=0.23.1' marimo-jupyter-extension
+pip install 'marimo>=0.23.4' marimo-jupyter-extension
 ```
 
 Launch JupyterLab and click the marimo icon in the launcher.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,8 +3,7 @@
 ## Requirements
 
 - Python 3.10+
-- marimo >= 0.23.4 (earlier releases leak orphan kernel/LSP children when marimo is killed; see [marimo PR #9257](https://github.com/marimo-team/marimo/pull/9257))
-- jupyter-server-proxy (installed automatically)
+- marimo >= 0.23.4
 
 ## Basic Installation
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.10+
-- marimo >= 0.23.1
+- marimo >= 0.23.4 (earlier releases leak orphan kernel/LSP children when marimo is killed; see [marimo PR #9257](https://github.com/marimo-team/marimo/pull/9257))
 - jupyter-server-proxy (installed automatically)
 
 ## Basic Installation
@@ -11,7 +11,7 @@
 `marimo-jupyter-extension` requires marimo but does not declare it as a dependency, allowing flexible installation scenarios.
 
 ```bash
-pip install 'marimo>=0.23.1' marimo-jupyter-extension
+pip install 'marimo>=0.23.4' marimo-jupyter-extension
 ```
 
 Or with uv:
@@ -29,7 +29,7 @@ FROM quay.io/jupyterhub/jupyterhub:latest
 RUN cd /srv/jupyterhub && jupyterhub --generate-config && \
     echo "c.JupyterHub.authenticator_class = 'dummy'" >> jupyterhub_config.py && \
     echo "c.DummyAuthenticator.password = 'demo'" >> jupyterhub_config.py && \
-    pip install --no-cache-dir notebook 'marimo>=0.23.1' marimo-jupyter-extension
+    pip install --no-cache-dir notebook 'marimo>=0.23.4' marimo-jupyter-extension
 RUN useradd -ms /bin/bash demo
 ```
 
@@ -57,7 +57,7 @@ RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download
     bash /root/miniforge.sh -b -p /opt/conda && rm /root/miniforge.sh
 
 # marimo in conda environment (user packages available)
-RUN /opt/conda/bin/pip install --no-cache-dir 'marimo>=0.23.1'
+RUN /opt/conda/bin/pip install --no-cache-dir 'marimo>=0.23.4'
 
 # marimo-jupyter-extension in Jupyter's environment
 RUN /usr/bin/pip install --no-cache-dir marimo-jupyter-extension

--- a/docs/jupyterhub.md
+++ b/docs/jupyterhub.md
@@ -64,7 +64,7 @@ dependencies = [
     "notebook>=7.5.0",
     "oauthenticator>=17.3.0",
     "jupyterhub-systemdspawner>=1.0.2",
-    "marimo>=0.23.1",
+    "marimo>=0.23.4",
     "marimo-jupyter-extension>=0.1.0",
 ]
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -80,10 +80,10 @@ For JupyterHub, add the same line to `jupyterhub_config.py`.
 
 **Cause**: marimo version is too old.
 
-**Solution**: Upgrade to marimo 0.23.1 or newer:
+**Solution**: Upgrade to marimo 0.23.4 or newer:
 
 ```bash
-pip install 'marimo>=0.23.1'
+pip install 'marimo>=0.23.4'
 ```
 
 ### JupyterHub Issues

--- a/example/opt/jupyterhub/pyproject.toml
+++ b/example/opt/jupyterhub/pyproject.toml
@@ -9,6 +9,6 @@ dependencies = [
     "notebook>=7.5.0",
     "oauthenticator>=17.3.0",
     "jupyterhub-systemdspawner>=1.0.2",
-    "marimo>=0.18.4",
+    "marimo>=0.23.4",
     "marimo-jupyter-extension>=0.0.4",
 ]

--- a/labextension/src/sidebar.ts
+++ b/labextension/src/sidebar.ts
@@ -190,13 +190,20 @@ export class MarimoSidebar extends Widget {
 
   /**
    * Hit the proxy directly to trigger ensure_process() and start marimo.
+   * Bounded by HEALTH_FETCH_TIMEOUT_MS so a hung proxy can't stall the UI.
    */
   private async _probeProxyHealth(): Promise<boolean> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      HEALTH_FETCH_TIMEOUT_MS,
+    );
     try {
       const baseUrl = this._getMarimoBaseUrl();
       const response = await fetch(`${baseUrl}health`, {
         method: 'GET',
         credentials: 'same-origin',
+        signal: controller.signal,
       });
       if (response.ok) {
         const data = (await response.json()) as { status: string };
@@ -205,6 +212,8 @@ export class MarimoSidebar extends Widget {
       return false;
     } catch {
       return false;
+    } finally {
+      clearTimeout(timeoutId);
     }
   }
 

--- a/labextension/src/sidebar.ts
+++ b/labextension/src/sidebar.ts
@@ -1,10 +1,13 @@
 import { PageConfig } from '@jupyterlab/coreutils';
 import type { CommandRegistry } from '@lumino/commands';
+import type { Message } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 import { marimoIcon } from './icons';
 import { updateWidgetTitles } from './iframe-widget';
 
 const SIDEBAR_CLASS = 'jp-MarimoSidebar';
+const POLL_INTERVAL_MS = 5000;
+const HEALTH_FETCH_TIMEOUT_MS = 15000;
 
 interface RunningSession {
   sessionId: string;
@@ -13,6 +16,13 @@ interface RunningSession {
   initializationId: string;
   lastModified: number;
 }
+
+interface HealthStatus {
+  process_alive: boolean;
+  marimo_healthy: boolean;
+}
+
+type ServerState = 'running' | 'unhealthy' | 'stopped';
 
 /**
  * A sidebar panel for marimo quick actions.
@@ -25,6 +35,7 @@ export class MarimoSidebar extends Widget {
   private _statusText: HTMLElement | null = null;
   private _serverControlsContainer: HTMLElement | null = null;
   private _startServerContainer: HTMLElement | null = null;
+  private _hasAutoStarted = false;
 
   constructor(commands: CommandRegistry) {
     super();
@@ -35,14 +46,19 @@ export class MarimoSidebar extends Widget {
     this.title.caption = 'marimo';
 
     this._buildUI();
-    this._startPolling();
   }
 
   dispose(): void {
-    if (this._refreshInterval !== null) {
-      window.clearInterval(this._refreshInterval);
-    }
+    this._stopPolling();
     super.dispose();
+  }
+
+  protected onAfterShow(_msg: Message): void {
+    this._startPolling();
+  }
+
+  protected onAfterHide(_msg: Message): void {
+    this._stopPolling();
   }
 
   private _getMarimoBaseUrl(): string {
@@ -51,18 +67,44 @@ export class MarimoSidebar extends Widget {
   }
 
   private _startPolling(): void {
+    if (this._refreshInterval !== null) {
+      return; // Already polling
+    }
     // Initial check
     this._refreshStatus();
     // Refresh status and sessions every 5 seconds
     this._refreshInterval = window.setInterval(() => {
       this._refreshStatus();
-    }, 5000);
+    }, POLL_INTERVAL_MS);
+  }
+
+  private _stopPolling(): void {
+    if (this._refreshInterval !== null) {
+      window.clearInterval(this._refreshInterval);
+      this._refreshInterval = null;
+    }
   }
 
   private async _refreshStatus(): Promise<void> {
-    const isRunning = await this._checkServerStatus();
-    this._updateServerStatus(isRunning);
-    if (isRunning) {
+    const status = await this._checkHealth();
+    const state: ServerState =
+      status.process_alive && status.marimo_healthy
+        ? 'running'
+        : status.process_alive
+          ? 'unhealthy'
+          : 'stopped';
+
+    // Auto-start marimo on first load if it hasn't been started yet.
+    // The health endpoint never triggers ensure_process(), so we do
+    // a one-time probe through the proxy to kick off the process.
+    if (state === 'stopped' && !this._hasAutoStarted) {
+      this._hasAutoStarted = true;
+      this._startServer();
+      return;
+    }
+
+    this._updateServerStatus(state);
+    if (state === 'running') {
       await this._refreshSessions();
     } else {
       this._updateSessionsList([]);
@@ -110,7 +152,41 @@ export class MarimoSidebar extends Widget {
     }
   }
 
-  private async _isServerHealthy(): Promise<boolean> {
+  /**
+   * Check marimo health via the /marimo-tools/health endpoint, which
+   * checks process liveness before proxying to avoid the ensure_process()
+   * deadlock when the marimo process has exited.
+   */
+  private async _checkHealth(): Promise<HealthStatus> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      HEALTH_FETCH_TIMEOUT_MS,
+    );
+    try {
+      const baseUrl = PageConfig.getBaseUrl();
+      const response = await fetch(`${baseUrl}marimo-tools/health`, {
+        method: 'GET',
+        credentials: 'same-origin',
+        signal: controller.signal,
+      });
+      if (response.ok) {
+        return (await response.json()) as HealthStatus;
+      }
+      return { process_alive: false, marimo_healthy: false };
+    } catch {
+      return { process_alive: false, marimo_healthy: false };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Trigger the proxy to start marimo by hitting /marimo/health directly.
+   * This is used only during explicit "Start Server" — it intentionally
+   * goes through jupyter-server-proxy to trigger ensure_process().
+   */
+  private async _probeProxyHealth(): Promise<boolean> {
     try {
       const baseUrl = this._getMarimoBaseUrl();
       const response = await fetch(`${baseUrl}health`, {
@@ -118,9 +194,7 @@ export class MarimoSidebar extends Widget {
         credentials: 'same-origin',
       });
       if (response.ok) {
-        const data = (await response.json()) as {
-          status: string;
-        };
+        const data = (await response.json()) as { status: string };
         return data.status === 'healthy';
       }
       return false;
@@ -129,27 +203,34 @@ export class MarimoSidebar extends Widget {
     }
   }
 
-  private async _checkServerStatus(): Promise<boolean> {
-    return this._isServerHealthy();
-  }
-
-  private _updateServerStatus(isRunning: boolean): void {
+  private _updateServerStatus(state: ServerState): void {
     if (this._statusDot && this._statusText) {
-      if (isRunning) {
-        this._statusDot.className = 'jp-MarimoSidebar-statusDot jp-mod-ready';
-        this._statusText.textContent = 'Running';
-      } else {
-        this._statusDot.className = 'jp-MarimoSidebar-statusDot jp-mod-error';
-        this._statusText.textContent = 'Stopped';
+      switch (state) {
+        case 'running':
+          this._statusDot.className =
+            'jp-MarimoSidebar-statusDot jp-mod-ready';
+          this._statusText.textContent = 'Running';
+          break;
+        case 'unhealthy':
+          this._statusDot.className =
+            'jp-MarimoSidebar-statusDot jp-mod-warning';
+          this._statusText.textContent = 'Unhealthy';
+          break;
+        case 'stopped':
+          this._statusDot.className =
+            'jp-MarimoSidebar-statusDot jp-mod-error';
+          this._statusText.textContent = 'Stopped';
+          break;
       }
     }
+    // Show restart for running or unhealthy, start for stopped
     if (this._serverControlsContainer) {
-      this._serverControlsContainer.style.display = isRunning
-        ? 'flex'
-        : 'none';
+      this._serverControlsContainer.style.display =
+        state !== 'stopped' ? 'flex' : 'none';
     }
     if (this._startServerContainer) {
-      this._startServerContainer.style.display = isRunning ? 'none' : 'flex';
+      this._startServerContainer.style.display =
+        state === 'stopped' ? 'flex' : 'none';
     }
   }
 
@@ -162,8 +243,8 @@ export class MarimoSidebar extends Widget {
       // Making a request to the proxy URL triggers jupyter-server-proxy to start the process
       const maxAttempts = 15;
       for (let i = 0; i < maxAttempts; i++) {
-        if (await this._isServerHealthy()) {
-          this._updateServerStatus(true);
+        if (await this._probeProxyHealth()) {
+          this._updateServerStatus('running');
           await this._refreshSessions();
           return;
         }
@@ -171,9 +252,9 @@ export class MarimoSidebar extends Widget {
       }
 
       // If we get here, the server didn't start successfully
-      this._updateServerStatus(false);
+      this._updateServerStatus('stopped');
     } catch {
-      this._updateServerStatus(false);
+      this._updateServerStatus('stopped');
     }
   }
 
@@ -208,7 +289,7 @@ export class MarimoSidebar extends Widget {
       // Wait for the server to come back up
       await this._waitForServer();
     } catch {
-      this._updateServerStatus(false);
+      this._updateServerStatus('stopped');
     }
   }
 
@@ -217,15 +298,16 @@ export class MarimoSidebar extends Widget {
 
     for (let i = 0; i < maxAttempts; i++) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      if (await this._isServerHealthy()) {
-        this._updateServerStatus(true);
+      const status = await this._checkHealth();
+      if (status.process_alive && status.marimo_healthy) {
+        this._updateServerStatus('running');
         await this._refreshSessions();
         return;
       }
     }
 
     // If we get here, the server didn't come back up
-    this._updateServerStatus(false);
+    this._updateServerStatus('stopped');
   }
 
   private _updateSessionsList(sessions: RunningSession[]): void {

--- a/labextension/src/sidebar.ts
+++ b/labextension/src/sidebar.ts
@@ -85,14 +85,15 @@ export class MarimoSidebar extends Widget {
     }
   }
 
+  private _stateFromHealth(status: HealthStatus): ServerState {
+    if (status.process_alive && status.marimo_healthy) {
+      return 'running';
+    }
+    return status.process_alive ? 'unhealthy' : 'stopped';
+  }
+
   private async _refreshStatus(): Promise<void> {
-    const status = await this._checkHealth();
-    const state: ServerState =
-      status.process_alive && status.marimo_healthy
-        ? 'running'
-        : status.process_alive
-          ? 'unhealthy'
-          : 'stopped';
+    const state = this._stateFromHealth(await this._checkHealth());
 
     // Auto-start marimo on first load if it hasn't been started yet.
     // The health endpoint never triggers ensure_process(), so we do
@@ -153,9 +154,9 @@ export class MarimoSidebar extends Widget {
   }
 
   /**
-   * Check marimo health via the /marimo-tools/health endpoint, which
-   * checks process liveness before proxying to avoid the ensure_process()
-   * deadlock when the marimo process has exited.
+   * Poll marimo health via /marimo-tools/health. The handler reports
+   * proc liveness without ever triggering ensure_process(), so polling
+   * here will not spawn marimo when it is stopped.
    */
   private async _checkHealth(): Promise<HealthStatus> {
     const controller = new AbortController();
@@ -298,8 +299,7 @@ export class MarimoSidebar extends Widget {
 
     for (let i = 0; i < maxAttempts; i++) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      const status = await this._checkHealth();
-      if (status.process_alive && status.marimo_healthy) {
+      if (this._stateFromHealth(await this._checkHealth()) === 'running') {
         this._updateServerStatus('running');
         await this._refreshSessions();
         return;

--- a/labextension/src/sidebar.ts
+++ b/labextension/src/sidebar.ts
@@ -36,6 +36,7 @@ export class MarimoSidebar extends Widget {
   private _serverControlsContainer: HTMLElement | null = null;
   private _startServerContainer: HTMLElement | null = null;
   private _hasAutoStarted = false;
+  private _refreshInFlight = false;
 
   constructor(commands: CommandRegistry) {
     super();
@@ -93,22 +94,29 @@ export class MarimoSidebar extends Widget {
   }
 
   private async _refreshStatus(): Promise<void> {
-    const state = this._stateFromHealth(await this._checkHealth());
-
-    // Auto-start marimo on first load if it hasn't been started yet.
-    // The health endpoint never triggers ensure_process(), so we do
-    // a one-time probe through the proxy to kick off the process.
-    if (state === 'stopped' && !this._hasAutoStarted) {
-      this._hasAutoStarted = true;
-      this._startServer();
+    if (this._refreshInFlight) {
       return;
     }
+    this._refreshInFlight = true;
+    try {
+      const state = this._stateFromHealth(await this._checkHealth());
 
-    this._updateServerStatus(state);
-    if (state === 'running') {
-      await this._refreshSessions();
-    } else {
-      this._updateSessionsList([]);
+      // Auto-start marimo on first load. /marimo-tools/health never
+      // spawns, so we kick the proxy via /marimo/health below.
+      if (state === 'stopped' && !this._hasAutoStarted) {
+        this._hasAutoStarted = true;
+        this._startServer();
+        return;
+      }
+
+      this._updateServerStatus(state);
+      if (state === 'running') {
+        await this._refreshSessions();
+      } else {
+        this._updateSessionsList([]);
+      }
+    } finally {
+      this._refreshInFlight = false;
     }
   }
 
@@ -154,9 +162,7 @@ export class MarimoSidebar extends Widget {
   }
 
   /**
-   * Poll marimo health via /marimo-tools/health. The handler reports
-   * proc liveness without ever triggering ensure_process(), so polling
-   * here will not spawn marimo when it is stopped.
+   * Poll marimo liveness without ever spawning it.
    */
   private async _checkHealth(): Promise<HealthStatus> {
     const controller = new AbortController();
@@ -183,9 +189,7 @@ export class MarimoSidebar extends Widget {
   }
 
   /**
-   * Trigger the proxy to start marimo by hitting /marimo/health directly.
-   * This is used only during explicit "Start Server" — it intentionally
-   * goes through jupyter-server-proxy to trigger ensure_process().
+   * Hit the proxy directly to trigger ensure_process() and start marimo.
    */
   private async _probeProxyHealth(): Promise<boolean> {
     try {
@@ -306,7 +310,6 @@ export class MarimoSidebar extends Widget {
       }
     }
 
-    // If we get here, the server didn't come back up
     this._updateServerStatus('stopped');
   }
 

--- a/marimo_jupyter_extension/config.py
+++ b/marimo_jupyter_extension/config.py
@@ -103,6 +103,7 @@ class MarimoProxyConfig(Configurable):
     ).tag(config=True)
 
     idle_timeout = Float(
+        default_value=None,
         allow_none=True,
         help=(
             "Minutes of no connection before shutting down the marimo server. "
@@ -111,6 +112,7 @@ class MarimoProxyConfig(Configurable):
     ).tag(config=True)
 
     session_ttl = Int(
+        default_value=None,
         allow_none=True,
         help=(
             "Seconds to wait before closing a session on websocket "

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -138,13 +138,13 @@ class HealthHandler(JupyterHandler):
                 if v:
                     forward_headers[h] = v
 
-            # Internal loopback to our own Jupyter server; cert validation
-            # off is intentional (self-signed dev certs, no external trust).
+            # follow_redirects=False prevents forwarded Cookie/Authorization
+            # leaking to a third party if the proxy target returns a 3xx.
             response = await AsyncHTTPClient().fetch(
                 health_url,
                 request_timeout=10,
                 headers=forward_headers,
-                validate_cert=False,
+                follow_redirects=False,
             )
             data = json.loads(response.body)
             marimo_healthy = data.get("status") == "healthy"
@@ -190,6 +190,14 @@ async def _proc_watcher_loop(server_app):
             ):
                 await asyncio.sleep(_WATCHER_POLL_INTERVAL)
                 continue
+
+            # Suppress simpervisor's auto-restart: on non-zero exit it
+            # would re-spawn into the proxy's still-cached port and
+            # collide with our fresh spawn loop. Real respawns must come
+            # from ensure_process() on a real request.
+            restart_future = getattr(proc, "_restart_process_future", None)
+            if restart_future is not None and not restart_future.done():
+                restart_future.cancel()
 
             try:
                 await proc.proc.wait()

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -16,12 +16,7 @@ _WATCHER_POLL_INTERVAL = 1.0
 
 
 def _find_marimo_proxy_state(web_app):
-    """Find the marimo proxy handler's state dict.
-
-    Searches through the web_app's registered handlers to find the
-    jupyter-server-proxy handler for marimo and returns its state dict.
-    Supports both legacy tornado (<6) .handlers and modern (.default_router).
-    """
+    """Return the jupyter-server-proxy state dict for the marimo route."""
     # Modern tornado (6.x+): handlers are in default_router.rules.
     # Each Rule stores its handler kwargs as `target_kwargs`.
     if hasattr(web_app, "default_router"):
@@ -118,21 +113,10 @@ class RestartHandler(JupyterHandler):
 
 
 class HealthHandler(JupyterHandler):
-    """Sidebar-friendly health check that never triggers ensure_process().
-
-    Reports state without spawning. The proc watcher (started in
-    _load_jupyter_server_extension) keeps proxy_state['proc'] in sync
-    with reality, so a missing or non-running proc here means marimo is
-    really not running — no in-handler cleanup needed.
-    """
+    """Liveness probe used by the sidebar; never spawns marimo."""
 
     @web.authenticated
     async def get(self):
-        """Check marimo server health.
-
-        GET /marimo-tools/health
-        Response: {"process_alive": bool, "marimo_healthy": bool}
-        """
         proxy_state = _find_marimo_proxy_state(self.application)
         proc = proxy_state.get("proc") if proxy_state else None
 
@@ -154,6 +138,8 @@ class HealthHandler(JupyterHandler):
                 if v:
                     forward_headers[h] = v
 
+            # Internal loopback to our own Jupyter server; cert validation
+            # off is intentional (self-signed dev certs, no external trust).
             response = await AsyncHTTPClient().fetch(
                 health_url,
                 request_timeout=10,
@@ -189,14 +175,9 @@ def _is_process_alive(proc):
 async def _proc_watcher_loop(server_app):
     """Evict stale proc from jupyter-server-proxy state when marimo dies.
 
-    The proxy caches a SupervisedProcess in proxy_state['proc']. When marimo
-    self-exits (e.g. idle --timeout) the cached handle outlives the process;
-    the next request hits ensure_process()'s cleanup path which awaits
-    proc.kill() on a reaped child and raises ProcessLookupError as a 500.
-
-    This loop watches each generation of proc, awaits its exit, and deletes
-    the entry under proc_lock. The next request then spawns a fresh process
-    instead of trying to kill a corpse.
+    Without this, a self-exited marimo leaves a cached SupervisedProcess
+    behind; the next request's ensure_process() cleanup awaits kill() on
+    a reaped child and raises ProcessLookupError as a 500.
     """
     while True:
         try:

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -8,8 +8,11 @@ from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join
 from tornado import web
 from tornado.httpclient import AsyncHTTPClient
+from tornado.ioloop import IOLoop
 
 from .convert import convert_notebook_to_marimo
+
+_WATCHER_POLL_INTERVAL = 1.0
 
 
 def _find_marimo_proxy_state(web_app):
@@ -115,12 +118,12 @@ class RestartHandler(JupyterHandler):
 
 
 class HealthHandler(JupyterHandler):
-    """Health check that avoids the jupyter-server-proxy deadlock.
+    """Sidebar-friendly health check that never triggers ensure_process().
 
-    When marimo has exited, polling /marimo/health through the proxy triggers
-    ensure_process() which hangs on the dead process. This handler checks
-    process liveness first (instant), cleans up stale state if dead, and only
-    proxies the health check to marimo when the process is alive.
+    Reports state without spawning. The proc watcher (started in
+    _load_jupyter_server_extension) keeps proxy_state['proc'] in sync
+    with reality, so a missing or non-running proc here means marimo is
+    really not running — no in-handler cleanup needed.
     """
 
     @web.authenticated
@@ -129,41 +132,14 @@ class HealthHandler(JupyterHandler):
 
         GET /marimo-tools/health
         Response: {"process_alive": bool, "marimo_healthy": bool}
-
-        This endpoint NEVER triggers ensure_process() — it only checks
-        existing state. Starting marimo is left to explicit user actions
-        (Start Server button, opening a notebook) which go through the
-        proxy directly.
         """
         proxy_state = _find_marimo_proxy_state(self.application)
+        proc = proxy_state.get("proc") if proxy_state else None
 
-        if not proxy_state:
-            self.finish({"process_alive": False, "marimo_healthy": False})
-            return
-
-        proc = proxy_state.get("proc")
-
-        # No process in state — either never started or previously cleaned up
-        if proc is None:
-            self.finish({"process_alive": False, "marimo_healthy": False})
-            return
-
-        # Process exists but has exited — clean up stale state so the next
-        # real request (notebook open, Start Server) spawns fresh instead
-        # of deadlocking in ensure_process()
         if not _is_process_alive(proc):
-            returncode = getattr(proc, "returncode", "unknown")
-            self.log.info(
-                "marimo process has exited (returncode: %s), "
-                "cleaning up proxy state",
-                returncode,
-            )
-            await _cleanup_proxy_state(proxy_state)
             self.finish({"process_alive": False, "marimo_healthy": False})
             return
 
-        # Process is alive — proxy the health check to marimo.
-        # ensure_process() is a no-op when proc is already in state.
         try:
             base_url = self.application.settings.get("base_url", "/")
             health_url = url_path_join(
@@ -172,24 +148,18 @@ class HealthHandler(JupyterHandler):
                 "marimo/health",
             )
 
-            # Forward jupyter auth (cookies + Authorization) so the internal
-            # request authenticates the same way the original did.
             forward_headers = {}
-            cookie = self.request.headers.get("Cookie", "")
-            if cookie:
-                forward_headers["Cookie"] = cookie
-            auth = self.request.headers.get("Authorization", "")
-            if auth:
-                forward_headers["Authorization"] = auth
+            for h in ("Cookie", "Authorization"):
+                v = self.request.headers.get(h, "")
+                if v:
+                    forward_headers[h] = v
 
-            http_client = AsyncHTTPClient()
-            response = await http_client.fetch(
+            response = await AsyncHTTPClient().fetch(
                 health_url,
                 request_timeout=10,
                 headers=forward_headers,
                 validate_cert=False,
             )
-
             data = json.loads(response.body)
             marimo_healthy = data.get("status") == "healthy"
 
@@ -209,32 +179,56 @@ class HealthHandler(JupyterHandler):
 
 def _is_process_alive(proc):
     """Check if a jupyter-server-proxy managed process is still running."""
-    if proc is None:
-        return False
-    if isinstance(proc, str):
-        # "process not managed by jupyter-server-proxy"
+    if proc is None or isinstance(proc, str):
         return False
     if hasattr(proc, "running"):
         return proc.running
     return True
 
 
-async def _cleanup_proxy_state(proxy_state):
-    """Remove stale proc from proxy state so next request spawns fresh.
+async def _proc_watcher_loop(server_app):
+    """Evict stale proc from jupyter-server-proxy state when marimo dies.
 
-    Uses a timeout to avoid blocking if proc_lock is already held by a
-    hung ensure_process() call.
+    The proxy caches a SupervisedProcess in proxy_state['proc']. When marimo
+    self-exits (e.g. idle --timeout) the cached handle outlives the process;
+    the next request hits ensure_process()'s cleanup path which awaits
+    proc.kill() on a reaped child and raises ProcessLookupError as a 500.
+
+    This loop watches each generation of proc, awaits its exit, and deletes
+    the entry under proc_lock. The next request then spawns a fresh process
+    instead of trying to kill a corpse.
     """
+    while True:
+        try:
+            proxy_state = _find_marimo_proxy_state(server_app.web_app)
+            proc = proxy_state.get("proc") if proxy_state else None
+            if (
+                proc is None
+                or isinstance(proc, str)
+                or not hasattr(proc, "proc")
+            ):
+                await asyncio.sleep(_WATCHER_POLL_INTERVAL)
+                continue
 
-    async def _do_cleanup():
-        async with proxy_state["proc_lock"]:
-            if "proc" in proxy_state:
-                del proxy_state["proc"]
+            try:
+                await proc.proc.wait()
+            except Exception:
+                pass
 
-    try:
-        await asyncio.wait_for(_do_cleanup(), timeout=5)
-    except (asyncio.TimeoutError, Exception):
-        pass
+            async with proxy_state["proc_lock"]:
+                if proxy_state.get("proc") is proc:
+                    rc = getattr(proc.proc, "returncode", "?")
+                    server_app.log.info(
+                        "marimo proc exited (rc=%s); evicting from "
+                        "jupyter-server-proxy state",
+                        rc,
+                    )
+                    del proxy_state["proc"]
+        except Exception as e:
+            server_app.log.warning(
+                "marimo proc watcher iteration failed: %s", e
+            )
+            await asyncio.sleep(_WATCHER_POLL_INTERVAL)
 
 
 class ConfigHandler(JupyterHandler):
@@ -339,4 +333,5 @@ def _load_jupyter_server_extension(server_app):
             (url_path_join(base_url, "marimo-tools/config"), ConfigHandler),
         ],
     )
+    IOLoop.current().spawn_callback(_proc_watcher_loop, server_app)
     server_app.log.info("marimo-jupyter-extension tools extension loaded")

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -1,11 +1,13 @@
 """Jupyter server extension handlers for marimo tools."""
 
+import asyncio
 import json
 from pathlib import Path
 
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join
 from tornado import web
+from tornado.httpclient import AsyncHTTPClient
 
 from .convert import convert_notebook_to_marimo
 
@@ -15,12 +17,32 @@ def _find_marimo_proxy_state(web_app):
 
     Searches through the web_app's registered handlers to find the
     jupyter-server-proxy handler for marimo and returns its state dict.
+    Supports both legacy tornado (<6) .handlers and modern (.default_router).
     """
-    for host_pattern, handlers in web_app.handlers:
-        for spec in handlers:
-            if hasattr(spec, "kwargs") and "state" in spec.kwargs:
-                if "marimo" in str(spec.regex.pattern):
-                    return spec.kwargs["state"]
+    # Modern tornado (6.x+): handlers are in default_router.rules.
+    # Each Rule stores its handler kwargs as `target_kwargs`.
+    if hasattr(web_app, "default_router"):
+        for host_rule in web_app.default_router.rules:
+            target = getattr(host_rule, "target", None)
+            if not hasattr(target, "rules"):
+                continue
+            for rule in target.rules:
+                kwargs = getattr(rule, "target_kwargs", None) or {}
+                if "state" not in kwargs:
+                    continue
+                matcher = getattr(rule, "matcher", None)
+                regex = getattr(matcher, "regex", None)
+                if regex and "marimo" in regex.pattern:
+                    return kwargs["state"]
+
+    # Legacy tornado: handlers stored as (host_pattern, [URLSpec, ...])
+    if hasattr(web_app, "handlers"):
+        for _host_pattern, handlers in web_app.handlers:
+            for spec in handlers:
+                if hasattr(spec, "kwargs") and "state" in spec.kwargs:
+                    if "marimo" in str(spec.regex.pattern):
+                        return spec.kwargs["state"]
+
     return None
 
 
@@ -90,6 +112,129 @@ class RestartHandler(JupyterHandler):
         except Exception as e:
             self.set_status(500)
             self.finish({"success": False, "error": str(e)})
+
+
+class HealthHandler(JupyterHandler):
+    """Health check that avoids the jupyter-server-proxy deadlock.
+
+    When marimo has exited, polling /marimo/health through the proxy triggers
+    ensure_process() which hangs on the dead process. This handler checks
+    process liveness first (instant), cleans up stale state if dead, and only
+    proxies the health check to marimo when the process is alive.
+    """
+
+    @web.authenticated
+    async def get(self):
+        """Check marimo server health.
+
+        GET /marimo-tools/health
+        Response: {"process_alive": bool, "marimo_healthy": bool}
+
+        This endpoint NEVER triggers ensure_process() — it only checks
+        existing state. Starting marimo is left to explicit user actions
+        (Start Server button, opening a notebook) which go through the
+        proxy directly.
+        """
+        proxy_state = _find_marimo_proxy_state(self.application)
+
+        if not proxy_state:
+            self.finish({"process_alive": False, "marimo_healthy": False})
+            return
+
+        proc = proxy_state.get("proc")
+
+        # No process in state — either never started or previously cleaned up
+        if proc is None:
+            self.finish({"process_alive": False, "marimo_healthy": False})
+            return
+
+        # Process exists but has exited — clean up stale state so the next
+        # real request (notebook open, Start Server) spawns fresh instead
+        # of deadlocking in ensure_process()
+        if not _is_process_alive(proc):
+            returncode = getattr(proc, "returncode", "unknown")
+            self.log.info(
+                "marimo process has exited (returncode: %s), "
+                "cleaning up proxy state",
+                returncode,
+            )
+            await _cleanup_proxy_state(proxy_state)
+            self.finish({"process_alive": False, "marimo_healthy": False})
+            return
+
+        # Process is alive — proxy the health check to marimo.
+        # ensure_process() is a no-op when proc is already in state.
+        try:
+            base_url = self.application.settings.get("base_url", "/")
+            health_url = url_path_join(
+                f"{self.request.protocol}://{self.request.host}",
+                base_url,
+                "marimo/health",
+            )
+
+            # Forward jupyter auth (cookies + Authorization) so the internal
+            # request authenticates the same way the original did.
+            forward_headers = {}
+            cookie = self.request.headers.get("Cookie", "")
+            if cookie:
+                forward_headers["Cookie"] = cookie
+            auth = self.request.headers.get("Authorization", "")
+            if auth:
+                forward_headers["Authorization"] = auth
+
+            http_client = AsyncHTTPClient()
+            response = await http_client.fetch(
+                health_url,
+                request_timeout=10,
+                headers=forward_headers,
+                validate_cert=False,
+            )
+
+            data = json.loads(response.body)
+            marimo_healthy = data.get("status") == "healthy"
+
+            if not marimo_healthy:
+                self.log.warning(
+                    "marimo process is running but health check returned: %s",
+                    response.body.decode(),
+                )
+
+            self.finish(
+                {"process_alive": True, "marimo_healthy": marimo_healthy}
+            )
+        except Exception as e:
+            self.log.warning("marimo health check failed: %s", e)
+            self.finish({"process_alive": True, "marimo_healthy": False})
+
+
+def _is_process_alive(proc):
+    """Check if a jupyter-server-proxy managed process is still running."""
+    if proc is None:
+        return False
+    if isinstance(proc, str):
+        # "process not managed by jupyter-server-proxy"
+        return False
+    if hasattr(proc, "running"):
+        return proc.running
+    return True
+
+
+async def _cleanup_proxy_state(proxy_state):
+    """Remove stale proc from proxy state so next request spawns fresh.
+
+    Uses a timeout to avoid blocking if proc_lock is already held by a
+    hung ensure_process() call.
+    """
+
+    async def _do_cleanup():
+        async with proxy_state["proc_lock"]:
+            if "proc" in proxy_state:
+                del proxy_state["proc"]
+
+    try:
+        await asyncio.wait_for(_do_cleanup(), timeout=5)
+    except (asyncio.TimeoutError, Exception):
+        pass
 
 
 class ConfigHandler(JupyterHandler):
@@ -186,6 +331,7 @@ def _load_jupyter_server_extension(server_app):
         [
             (url_path_join(base_url, "marimo-tools/convert"), ConvertHandler),
             (url_path_join(base_url, "marimo-tools/restart"), RestartHandler),
+            (url_path_join(base_url, "marimo-tools/health"), HealthHandler),
             (
                 url_path_join(base_url, "marimo-tools/create-stub"),
                 CreateStubHandler,

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -110,7 +110,9 @@ class TestFindMarimoProxyState:
     def _modern_web_app(self, inner_rules):
         target = SimpleNamespace(rules=inner_rules)
         host_rule = SimpleNamespace(target=target)
-        return SimpleNamespace(default_router=SimpleNamespace(rules=[host_rule]))
+        return SimpleNamespace(
+            default_router=SimpleNamespace(rules=[host_rule])
+        )
 
     def _legacy_spec(self, pattern, kwargs):
         spec = SimpleNamespace()
@@ -137,9 +139,7 @@ class TestFindMarimoProxyState:
             _find_marimo_proxy_state,
         )
 
-        web_app = self._modern_web_app(
-            [self._modern_rule(r"^/marimo/", {})]
-        )
+        web_app = self._modern_web_app([self._modern_rule(r"^/marimo/", {})])
         assert _find_marimo_proxy_state(web_app) is None
 
     def test_legacy_handlers_returns_marimo_state(self):
@@ -152,7 +152,10 @@ class TestFindMarimoProxyState:
         web_app = SimpleNamespace(
             handlers=[
                 (".*", [self._legacy_spec(r"^/other", {"state": {"x": 1}})]),
-                (".*", [self._legacy_spec(r"^/marimo/", {"state": marimo_state})]),
+                (
+                    ".*",
+                    [self._legacy_spec(r"^/marimo/", {"state": marimo_state})],
+                ),
             ]
         )
         assert _find_marimo_proxy_state(web_app) is marimo_state

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,6 +1,26 @@
 """Tests for the handlers module."""
 
+import asyncio
 import json
+import re
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_handler(handler_cls, *, application=None):
+    """Build a handler instance bypassing Tornado's initializer."""
+    handler = handler_cls.__new__(handler_cls)
+    handler.application = application
+    handler.current_user = "u"
+    handler.set_status = MagicMock()
+    handler.finish = MagicMock()
+    return handler
+
+
+def _run(handler, method_name):
+    """Invoke an @web.authenticated async method, bypassing the guard."""
+    method = getattr(type(handler), method_name).__wrapped__
+    asyncio.run(method(handler))
 
 
 class TestHandlers:
@@ -75,3 +95,155 @@ class TestConvertHandler:
         assert output_path == "test.py"
         # Would succeed
         assert input_path and output_path
+
+
+class TestFindMarimoProxyState:
+    """`_find_marimo_proxy_state` must work against both modern and
+    legacy tornado router shapes."""
+
+    def _modern_rule(self, pattern, kwargs):
+        return SimpleNamespace(
+            target_kwargs=kwargs,
+            matcher=SimpleNamespace(regex=re.compile(pattern)),
+        )
+
+    def _modern_web_app(self, inner_rules):
+        target = SimpleNamespace(rules=inner_rules)
+        host_rule = SimpleNamespace(target=target)
+        return SimpleNamespace(default_router=SimpleNamespace(rules=[host_rule]))
+
+    def _legacy_spec(self, pattern, kwargs):
+        spec = SimpleNamespace()
+        spec.regex = re.compile(pattern)
+        spec.kwargs = kwargs
+        return spec
+
+    def test_modern_router_returns_marimo_state(self):
+        from marimo_jupyter_extension.handlers import (
+            _find_marimo_proxy_state,
+        )
+
+        marimo_state = {"proc": "fake", "proc_lock": object()}
+        web_app = self._modern_web_app(
+            [
+                self._modern_rule(r"^/other", {"state": {"x": 1}}),
+                self._modern_rule(r"^/marimo/", {"state": marimo_state}),
+            ]
+        )
+        assert _find_marimo_proxy_state(web_app) is marimo_state
+
+    def test_modern_router_skips_specs_without_state(self):
+        from marimo_jupyter_extension.handlers import (
+            _find_marimo_proxy_state,
+        )
+
+        web_app = self._modern_web_app(
+            [self._modern_rule(r"^/marimo/", {})]
+        )
+        assert _find_marimo_proxy_state(web_app) is None
+
+    def test_legacy_handlers_returns_marimo_state(self):
+        from marimo_jupyter_extension.handlers import (
+            _find_marimo_proxy_state,
+        )
+
+        marimo_state = {"proc": "fake", "proc_lock": object()}
+        # Legacy shape: no `default_router`, only `.handlers`
+        web_app = SimpleNamespace(
+            handlers=[
+                (".*", [self._legacy_spec(r"^/other", {"state": {"x": 1}})]),
+                (".*", [self._legacy_spec(r"^/marimo/", {"state": marimo_state})]),
+            ]
+        )
+        assert _find_marimo_proxy_state(web_app) is marimo_state
+
+    def test_returns_none_when_no_marimo_route(self):
+        from marimo_jupyter_extension.handlers import (
+            _find_marimo_proxy_state,
+        )
+
+        web_app = self._modern_web_app(
+            [self._modern_rule(r"^/other", {"state": {"x": 1}})]
+        )
+        assert _find_marimo_proxy_state(web_app) is None
+
+
+class TestHealthHandler:
+    """`HealthHandler.get` reports liveness without spawning marimo."""
+
+    def test_returns_false_when_no_proxy_state(self):
+        from marimo_jupyter_extension import handlers
+        from marimo_jupyter_extension.handlers import HealthHandler
+
+        original = handlers._find_marimo_proxy_state
+        handlers._find_marimo_proxy_state = lambda _app: None
+        try:
+            handler = _make_handler(
+                HealthHandler, application=SimpleNamespace()
+            )
+            _run(handler, "get")
+        finally:
+            handlers._find_marimo_proxy_state = original
+
+        handler.finish.assert_called_once_with(
+            {"process_alive": False, "marimo_healthy": False}
+        )
+
+    def test_returns_false_when_proc_missing(self):
+        from marimo_jupyter_extension import handlers
+        from marimo_jupyter_extension.handlers import HealthHandler
+
+        original = handlers._find_marimo_proxy_state
+        handlers._find_marimo_proxy_state = lambda _app: {}
+        try:
+            handler = _make_handler(
+                HealthHandler, application=SimpleNamespace()
+            )
+            _run(handler, "get")
+        finally:
+            handlers._find_marimo_proxy_state = original
+
+        handler.finish.assert_called_once_with(
+            {"process_alive": False, "marimo_healthy": False}
+        )
+
+    def test_returns_false_when_proc_not_running(self):
+        from marimo_jupyter_extension import handlers
+        from marimo_jupyter_extension.handlers import HealthHandler
+
+        proc = SimpleNamespace(running=False)
+        original = handlers._find_marimo_proxy_state
+        handlers._find_marimo_proxy_state = lambda _app: {"proc": proc}
+        try:
+            handler = _make_handler(
+                HealthHandler, application=SimpleNamespace()
+            )
+            _run(handler, "get")
+        finally:
+            handlers._find_marimo_proxy_state = original
+
+        handler.finish.assert_called_once_with(
+            {"process_alive": False, "marimo_healthy": False}
+        )
+
+    def test_returns_false_when_proc_is_unmanaged_string(self):
+        """jupyter-server-proxy uses the string 'process not managed'
+        when it cannot supervise the process."""
+        from marimo_jupyter_extension import handlers
+        from marimo_jupyter_extension.handlers import HealthHandler
+
+        original = handlers._find_marimo_proxy_state
+        handlers._find_marimo_proxy_state = lambda _app: {
+            "proc": "process not managed"
+        }
+        try:
+            handler = _make_handler(
+                HealthHandler, application=SimpleNamespace()
+            )
+            _run(handler, "get")
+        finally:
+            handlers._find_marimo_proxy_state = original
+
+        handler.finish.assert_called_once_with(
+            {"process_alive": False, "marimo_healthy": False}
+        )


### PR DESCRIPTION
closes #83

Checking on a dead process caused an exception and deadlocked the plugin. We now proxy the request, first checking for the process, and then checking for health on polling.