### PR TITLE
chore: pin pnpm via packageManager

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
-          version: 10
+          package_json_file: labextension/package.json
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
-          version: 10
+          package_json_file: labextension/package.json
 
       - name: Install build tools
         run: pip install build hatch hatch-jupyter-builder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
-          version: 10
+          package_json_file: labextension/package.json
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/marimo-team/marimo-jupyter-extension/issues"
   },
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.28.2",
   "author": {
     "name": "Marimo Team"
   },


### PR DESCRIPTION
Adds `"packageManager": "pnpm@10.28.2"` to `package.json` and drops the redundant `version:` arg from `pnpm/action-setup` in CI.

The action now reads the version from `packageManager`, giving a single source of truth shared between local dev and CI. Matches the convention used in `marimo` and `marimo-lsp`.