### PR TITLE
chore(ci): add --ignore-scripts to pnpm install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           package_json_file: labextension/package.json
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: Check formatting (Biome)
         run: pnpm run format:check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build labextension
         run: |
           cd labextension
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm run build:prod
 
       - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           package_json_file: labextension/package.json
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: Run tests
         run: pnpm run test


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare in CI. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change.