### PR TITLE
refactor: use client side request for health check

### DIFF
--- a/labextension/src/sidebar.ts
+++ b/labextension/src/sidebar.ts
@@ -20,7 +20,6 @@ interface RunningSession {
 
 interface HealthStatus {
   process_alive: boolean;
-  marimo_healthy: boolean;
 }
 
 type ServerState = 'running' | 'unhealthy' | 'stopped';
@@ -103,11 +102,18 @@ export class MarimoSidebar extends Widget {
     }
   }
 
-  private _stateFromHealth(status: HealthStatus): ServerState {
-    if (status.process_alive && status.marimo_healthy) {
-      return 'running';
+  /**
+   * Combine server-side process state with a client-side reachability
+   * probe. The client probe takes the same path as the iframe, so the
+   * indicator stays consistent with what the user actually sees — see
+   * #95 for why a server-side HTTP probe can't.
+   */
+  private async _resolveServerState(): Promise<ServerState> {
+    const { process_alive } = await this._checkHealth();
+    if (!process_alive) {
+      return 'stopped';
     }
-    return status.process_alive ? 'unhealthy' : 'stopped';
+    return (await this._probeProxyHealth()) ? 'running' : 'unhealthy';
   }
 
   private async _refreshStatus(): Promise<void> {
@@ -116,7 +122,7 @@ export class MarimoSidebar extends Widget {
     }
     this._refreshInFlight = true;
     try {
-      const state = this._stateFromHealth(await this._checkHealth());
+      const state = await this._resolveServerState();
 
       // Auto-start marimo on first load. /marimo-tools/health never
       // spawns, so we kick the proxy via /marimo/health below.
@@ -195,9 +201,9 @@ export class MarimoSidebar extends Widget {
       if (response.ok) {
         return (await response.json()) as HealthStatus;
       }
-      return { process_alive: false, marimo_healthy: false };
+      return { process_alive: false };
     } catch {
-      return { process_alive: false, marimo_healthy: false };
+      return { process_alive: false };
     } finally {
       clearTimeout(timeoutId);
     }
@@ -325,7 +331,7 @@ export class MarimoSidebar extends Widget {
 
     for (let i = 0; i < maxAttempts; i++) {
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      if (this._stateFromHealth(await this._checkHealth()) === 'running') {
+      if ((await this._resolveServerState()) === 'running') {
         this._updateServerStatus('running');
         await this._refreshSessions();
         return;

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join
 from tornado import web
-from tornado.httpclient import AsyncHTTPClient
 from tornado.ioloop import IOLoop
 
 from . import version_info
@@ -115,62 +114,20 @@ class RestartHandler(JupyterHandler):
 
 
 class HealthHandler(JupyterHandler):
-    """Liveness probe used by the sidebar; never spawns marimo."""
+    """Process liveness probe used by the sidebar; never spawns marimo.
+
+    Only reports whether jupyter-server-proxy's SupervisedProcess is
+    running. Server-reachability is checked client-side from the sidebar
+    so the probe path matches the iframe's path (see #95 — a server-side
+    HTTP probe via self.request.host gets bounced by oauth2 redirects
+    on reverse-proxy setups even when marimo is fully reachable).
+    """
 
     @web.authenticated
     async def get(self):
-        # GET handlers are conventionally exempt from XSRF, but this
-        # endpoint forwards the caller's Cookie + Authorization onward
-        # to /marimo/health, so explicitly validate the inbound token
-        # to keep cross-origin pages from triggering a credentialed
-        # proxy probe. JupyterHandler.prepare() only auto-checks XSRF
-        # for non-GET methods, so the call is needed here.
-        self.check_xsrf_cookie()
-
         proxy_state = _find_marimo_proxy_state(self.application)
         proc = proxy_state.get("proc") if proxy_state else None
-
-        if not _is_process_alive(proc):
-            self.finish({"process_alive": False, "marimo_healthy": False})
-            return
-
-        try:
-            base_url = self.application.settings.get("base_url", "/")
-            health_url = url_path_join(
-                f"{self.request.protocol}://{self.request.host}",
-                base_url,
-                "marimo/health",
-            )
-
-            forward_headers = {}
-            for h in ("Cookie", "Authorization", "X-Xsrftoken"):
-                v = self.request.headers.get(h, "")
-                if v:
-                    forward_headers[h] = v
-
-            # follow_redirects=False prevents forwarded Cookie/Authorization
-            # leaking to a third party if the proxy target returns a 3xx.
-            response = await AsyncHTTPClient().fetch(
-                health_url,
-                request_timeout=10,
-                headers=forward_headers,
-                follow_redirects=False,
-            )
-            data = json.loads(response.body)
-            marimo_healthy = data.get("status") == "healthy"
-
-            if not marimo_healthy:
-                self.log.warning(
-                    "marimo process is running but health check returned: %s",
-                    response.body.decode(),
-                )
-
-            self.finish(
-                {"process_alive": True, "marimo_healthy": marimo_healthy}
-            )
-        except Exception as e:
-            self.log.warning("marimo health check failed: %s", e)
-            self.finish({"process_alive": True, "marimo_healthy": False})
+        self.finish({"process_alive": _is_process_alive(proc)})
 
 
 def _is_process_alive(proc):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -194,9 +194,7 @@ class TestHealthHandler:
         finally:
             handlers._find_marimo_proxy_state = original
 
-        handler.finish.assert_called_once_with(
-            {"process_alive": False, "marimo_healthy": False}
-        )
+        handler.finish.assert_called_once_with({"process_alive": False})
 
     def test_returns_false_when_proc_missing(self):
         from marimo_jupyter_extension import handlers
@@ -212,9 +210,7 @@ class TestHealthHandler:
         finally:
             handlers._find_marimo_proxy_state = original
 
-        handler.finish.assert_called_once_with(
-            {"process_alive": False, "marimo_healthy": False}
-        )
+        handler.finish.assert_called_once_with({"process_alive": False})
 
     def test_returns_false_when_proc_not_running(self):
         from marimo_jupyter_extension import handlers
@@ -231,9 +227,7 @@ class TestHealthHandler:
         finally:
             handlers._find_marimo_proxy_state = original
 
-        handler.finish.assert_called_once_with(
-            {"process_alive": False, "marimo_healthy": False}
-        )
+        handler.finish.assert_called_once_with({"process_alive": False})
 
     def test_returns_false_when_proc_is_unmanaged_string(self):
         """jupyter-server-proxy uses the string 'process not managed'
@@ -253,25 +247,7 @@ class TestHealthHandler:
         finally:
             handlers._find_marimo_proxy_state = original
 
-        handler.finish.assert_called_once_with(
-            {"process_alive": False, "marimo_healthy": False}
-        )
-
-    def test_raises_when_xsrf_check_fails(self):
-        """A CSRF-rejected probe must propagate as 403, not silently
-        succeed and forward credentials to /marimo/health."""
-        from tornado.web import HTTPError
-
-        from marimo_jupyter_extension.handlers import HealthHandler
-
-        handler = _make_handler(HealthHandler, application=SimpleNamespace())
-        handler.check_xsrf_cookie = MagicMock(
-            side_effect=HTTPError(403, "XSRF cookie does not match")
-        )
-        with pytest.raises(HTTPError) as exc_info:
-            _run(handler, "get")
-        assert exc_info.value.status_code == 403
-        handler.finish.assert_not_called()
+        handler.finish.assert_called_once_with({"process_alive": False})
 
 
 class TestLoadServerExtension:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -6,8 +6,6 @@ import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 def _make_handler(handler_cls, *, application=None):
     """Build a handler instance bypassing Tornado's initializer."""


### PR DESCRIPTION
Closes #95

Opposed to doing to the health check on the backend through proxy, `/health` is now checked through the frontend, and only spawned process is checked on the BE.