### PR TITLE
feat: add MarimoProxyConfig.default_file for new-notebook templates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,33 @@ c.MarimoProxyConfig.idle_timeout = 30.0
 # Seconds to keep a session alive after a websocket disconnect.
 # None (the default) keeps sessions open indefinitely.
 c.MarimoProxyConfig.session_ttl = 300
+
+# Path to a template file whose contents are used as the body of every
+# new notebook (POST /marimo-tools/create-stub). Read once at extension
+# load and cached for the server's lifetime; restart to pick up changes.
+# If the path doesn't exist at boot, this extension fails to load and
+# the "New Marimo Notebook" launcher entry will 404 until the path is
+# fixed and the server is restarted. The file is emitted verbatim —
+# pin __generated_with in the template if you care which version
+# reads it.
+c.MarimoProxyConfig.default_file = "/opt/marimo/notebook_template.py"
+```
+
+A typical template (e.g. with a shared `app.setup` block so every new
+notebook starts with imports in scope):
+
+```python
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+with app.setup(hide_code=True):
+    import os  # noqa: F401
+    from pathlib import Path  # noqa: F401
+
+if __name__ == "__main__":
+    app.run()
 ```
 
 ## Spawner Environment

--- a/marimo_jupyter_extension/config.py
+++ b/marimo_jupyter_extension/config.py
@@ -121,12 +121,28 @@ class MarimoProxyConfig(Configurable):
         ),
     ).tag(config=True)
 
+    default_file = Unicode(
+        allow_none=True,
+        help=(
+            "Path to a template file whose contents are used as the body of "
+            "newly created notebooks (via POST /marimo-tools/create-stub). "
+            "When set, the file is read once at extension load and cached "
+            "for the lifetime of the Jupyter Server; restart the server to "
+            "pick up changes. The contents are written verbatim; the "
+            "extension does not parse or substitute __generated_with."
+        ),
+    ).tag(config=True)
+
     @default("host")
     def _default_host(self):
         return _detect_localhost_host()
 
     @default("marimo_path")
     def _default_marimo_path(self):
+        return None
+
+    @default("default_file")
+    def _default_default_file(self):
         return None
 
     @default("uvx_path")
@@ -159,6 +175,7 @@ class Config:
     skip_update_check: bool = False
     idle_timeout: float | None = None
     session_ttl: int | None = None
+    default_file: str | None = None
 
 
 def get_config(traitlets_config: MarimoProxyConfig | None = None) -> Config:
@@ -189,6 +206,7 @@ def get_config(traitlets_config: MarimoProxyConfig | None = None) -> Config:
         skip_update_check=bool(cfg.skip_update_check),
         idle_timeout=cfg.idle_timeout,
         session_ttl=cfg.session_ttl,
+        default_file=cfg.default_file,
     )
 
 

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -326,9 +326,9 @@ def _load_default_file(server_app) -> str | None:
     if not cfg.default_file:
         return None
 
-    template_path = Path(cfg.default_file)
+    template_path = Path(cfg.default_file).expanduser()
     try:
-        content = template_path.read_text()
+        content = template_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         server_app.log.error(
             "c.MarimoProxyConfig.default_file points at %s but the "

--- a/marimo_jupyter_extension/handlers.py
+++ b/marimo_jupyter_extension/handlers.py
@@ -15,6 +15,11 @@ from .executable import MARIMO_VERSION
 
 _WATCHER_POLL_INTERVAL = 1.0
 
+# Key under which the cached default-file body is stored on
+# web_app.settings. Read once at extension load (see
+# _load_jupyter_server_extension) and consumed by CreateStubHandler.
+_DEFAULT_FILE_SETTING = "marimo_default_stub_content"
+
 
 def _find_marimo_proxy_state(web_app):
     """Return the jupyter-server-proxy state dict for the marimo route."""
@@ -247,25 +252,38 @@ class CreateStubHandler(JupyterHandler):
                 ]
             )
 
-        # Add marimo app boilerplate. Prefer the running marimo's
-        # version so the stub matches what will read it; fall back to
-        # the floor MARIMO_VERSION when marimo can't be queried (e.g.
-        # uvx mode with no marimo in the Jupyter env).
-        marimo_version = version_info.get_marimo_version() or MARIMO_VERSION
-        lines.extend(
-            [
-                "import marimo",
-                "",
-                f'__generated_with = "{marimo_version}"',
-                'app = marimo.App(width="medium")',
-                "",
-                "",
-                'if __name__ == "__main__":',
-                "    app.run()",
-                "",
-            ]
-        )
-
+        cached_default = self.application.settings.get(_DEFAULT_FILE_SETTING)
+        if cached_default is not None:
+            # Operator provided a template via
+            # c.MarimoProxyConfig.default_file — emit its contents
+            # verbatim after the optional PEP 723 header. The template
+            # is responsible for being a parseable marimo notebook
+            # (import marimo, app = marimo.App(...), the __main__
+            # block); we don't substitute __generated_with so the
+            # template's pin (if any) wins.
+            lines.append(cached_default.rstrip("\n"))
+        else:
+            # Default boilerplate. Prefer the running marimo's
+            # version so the stub matches what will read it; fall
+            # back to the floor MARIMO_VERSION when marimo can't be
+            # queried (e.g. uvx mode with no marimo in the Jupyter
+            # env).
+            marimo_version = (
+                version_info.get_marimo_version() or MARIMO_VERSION
+            )
+            lines.extend(
+                [
+                    "import marimo",
+                    "",
+                    f'__generated_with = "{marimo_version}"',
+                    'app = marimo.App(width="medium")',
+                    "",
+                    "",
+                    'if __name__ == "__main__":',
+                    "    app.run()",
+                ]
+            )
+        lines.append("")
         content = "\n".join(lines)
 
         try:
@@ -282,9 +300,66 @@ def _jupyter_server_extension_points():
     return [{"module": "marimo_jupyter_extension.handlers"}]
 
 
+def _load_default_file(server_app) -> str | None:
+    """Read the default_file template once at extension load.
+
+    Returns the file contents (a str) when default_file is configured,
+    or None when it isn't. Raises FileNotFoundError eagerly if the
+    operator configured a path that doesn't exist; jupyter-server's
+    extension manager logs the traceback and skips loading our
+    extension (the server itself keeps running, but
+    /marimo-tools/create-stub will 404 until the path is fixed and
+    the server is restarted). The alternative — deferring the read
+    to /marimo-tools/create-stub request handling — would surface
+    the misconfiguration as a 500 on every "New Notebook" click and
+    leave the boot log silent.
+
+    Reading once at startup (rather than per-request) also means
+    operators must restart Jupyter Server to pick up template
+    changes. This trades the convenience of hot-swap for a clearer
+    audit boundary: whatever was on disk when the server booted is
+    what users get.
+    """
+    from .config import get_config
+
+    cfg = get_config()
+    if not cfg.default_file:
+        return None
+
+    template_path = Path(cfg.default_file)
+    try:
+        content = template_path.read_text()
+    except FileNotFoundError:
+        server_app.log.error(
+            "c.MarimoProxyConfig.default_file points at %s but the "
+            "file does not exist; the marimo-jupyter-extension will "
+            "fail to load and /marimo-tools/create-stub will 404 "
+            "until this is fixed and the server is restarted.",
+            template_path,
+        )
+        raise
+    server_app.log.info(
+        "marimo-jupyter-extension loaded default notebook template "
+        "from %s (%d bytes); restart to pick up changes.",
+        template_path,
+        len(content),
+    )
+    return content
+
+
 def _load_jupyter_server_extension(server_app):
     """Load the jupyter server extension."""
     from . import __version__
+
+    # Read default_file first so a misconfigured path aborts the load
+    # cleanly. If we registered handlers first and *then* raised, the
+    # tornado routes would survive — CreateStubHandler would still be
+    # reachable but would silently fall back to the default boilerplate
+    # (cached content never landed on web_app.settings), masking the
+    # operator's misconfiguration. Failing before any side effects
+    # keeps "extension loaded successfully" and "template wired up" as
+    # a single atomic outcome.
+    default_file_content = _load_default_file(server_app)
 
     base_url = server_app.web_app.settings["base_url"]
     server_app.web_app.add_handlers(
@@ -301,6 +376,11 @@ def _load_jupyter_server_extension(server_app):
         ],
     )
     IOLoop.current().spawn_callback(_proc_watcher_loop, server_app)
+
+    if default_file_content is not None:
+        server_app.web_app.settings[_DEFAULT_FILE_SETTING] = (
+            default_file_content
+        )
 
     page_config = server_app.web_app.settings.setdefault(
         "page_config_data", {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,23 @@ class TestMarimoProxyConfig:
 
         assert config.no_sandbox is False
 
+    def test_default_file_is_none(self, clean_env):
+        """Default default_file should be None."""
+        from marimo_jupyter_extension.config import MarimoProxyConfig
+
+        config = MarimoProxyConfig()
+
+        assert config.default_file is None
+
+    def test_default_file_can_be_set(self, clean_env):
+        """default_file should accept a string path."""
+        from marimo_jupyter_extension.config import MarimoProxyConfig
+
+        config = MarimoProxyConfig()
+        config.default_file = "/etc/marimo/template.py"
+
+        assert config.default_file == "/etc/marimo/template.py"
+
 
 class TestGetConfig:
     """Test suite for get_config() function."""

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 import re
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -248,6 +250,172 @@ class TestHealthHandler:
         handler.finish.assert_called_once_with({"process_alive": False})
 
 
+class TestCreateStubHandler:
+    """`CreateStubHandler.post` writes a marimo notebook stub to disk.
+
+    When `c.MarimoProxyConfig.default_file` is configured, the cached
+    template content (stored on web_app.settings by
+    _load_jupyter_server_extension) is written verbatim; otherwise the
+    handler emits the built-in boilerplate.
+    """
+
+    def _build(self, body, settings=None):
+        from marimo_jupyter_extension.handlers import CreateStubHandler
+
+        app = SimpleNamespace(settings=settings or {})
+        handler = _make_handler(CreateStubHandler, application=app)
+        handler.request = SimpleNamespace(body=json.dumps(body).encode())
+        return handler
+
+    def test_writes_default_boilerplate_when_no_template(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stub_path = str(Path(tmpdir) / "out.py")
+            handler = self._build({"path": stub_path})
+
+            _run(handler, "post")
+
+            handler.finish.assert_called_once_with(
+                {"success": True, "path": stub_path}
+            )
+            content = Path(stub_path).read_text()
+            assert "import marimo" in content
+            assert "__generated_with" in content
+            assert 'app = marimo.App(width="medium")' in content
+            assert 'if __name__ == "__main__":' in content
+
+    def test_uses_cached_template_verbatim(self):
+        from marimo_jupyter_extension.handlers import _DEFAULT_FILE_SETTING
+
+        template = (
+            "import marimo\n\n"
+            '__generated_with = "0.99.0"\n'
+            'app = marimo.App(width="medium")\n\n'
+            "with app.setup(hide_code=True):\n"
+            "    from my_pkg import helper  # noqa: F401\n\n"
+            'if __name__ == "__main__":\n'
+            "    app.run()\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stub_path = str(Path(tmpdir) / "out.py")
+            handler = self._build(
+                {"path": stub_path},
+                settings={_DEFAULT_FILE_SETTING: template},
+            )
+
+            _run(handler, "post")
+
+            handler.finish.assert_called_once_with(
+                {"success": True, "path": stub_path}
+            )
+            assert Path(stub_path).read_text() == template
+
+    def test_cached_template_does_not_substitute_version(self):
+        """The cached template is emitted verbatim; the running marimo
+        version is *not* spliced into __generated_with."""
+        from marimo_jupyter_extension.handlers import _DEFAULT_FILE_SETTING
+
+        template = (
+            "import marimo\n"
+            '__generated_with = "0.0.0-template"\n'
+            'app = marimo.App(width="medium")\n'
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stub_path = str(Path(tmpdir) / "out.py")
+            handler = self._build(
+                {"path": stub_path},
+                settings={_DEFAULT_FILE_SETTING: template},
+            )
+            with patch(
+                "marimo_jupyter_extension.version_info.get_marimo_version",
+                return_value="9.9.9",
+            ):
+                _run(handler, "post")
+
+            content = Path(stub_path).read_text()
+            assert '"0.0.0-template"' in content
+            assert "9.9.9" not in content
+
+    def test_pep723_header_prepended_to_cached_template(self):
+        from marimo_jupyter_extension.handlers import _DEFAULT_FILE_SETTING
+
+        template = "import marimo\napp = marimo.App()\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            stub_path = str(Path(tmpdir) / "out.py")
+            handler = self._build(
+                {
+                    "path": stub_path,
+                    "venv": "/srv/envs/proj/bin/python3.13",
+                },
+                settings={_DEFAULT_FILE_SETTING: template},
+            )
+
+            _run(handler, "post")
+
+            content = Path(stub_path).read_text()
+            assert content.startswith("# /// script\n")
+            assert '# path = "/srv/envs/proj"\n' in content
+            assert content.endswith(template)
+
+    def test_missing_path_returns_400(self):
+        handler = self._build({})
+
+        _run(handler, "post")
+
+        handler.set_status.assert_called_once_with(400)
+        handler.finish.assert_called_once_with(
+            {"success": False, "error": "Missing path"}
+        )
+
+
+class TestLoadDefaultFile:
+    """`_load_default_file` reads the configured template once."""
+
+    def test_returns_none_when_unconfigured(self, clean_env):
+        from marimo_jupyter_extension.handlers import _load_default_file
+
+        server_app = MagicMock()
+        assert _load_default_file(server_app) is None
+
+    def test_reads_file_contents(self, clean_env):
+        from marimo_jupyter_extension import config as config_mod
+        from marimo_jupyter_extension.handlers import _load_default_file
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            template = Path(tmpdir) / "tmpl.py"
+            template.write_text("import marimo\napp = marimo.App()\n")
+
+            traitlets_config = config_mod.MarimoProxyConfig()
+            traitlets_config.default_file = str(template)
+
+            server_app = MagicMock()
+            with patch(
+                "marimo_jupyter_extension.config.get_config",
+                return_value=config_mod.get_config(traitlets_config),
+            ):
+                content = _load_default_file(server_app)
+
+            assert content == "import marimo\napp = marimo.App()\n"
+
+    def test_raises_on_missing_file(self, clean_env):
+        from marimo_jupyter_extension.config import MarimoProxyConfig
+        from marimo_jupyter_extension.handlers import _load_default_file
+
+        traitlets_config = MarimoProxyConfig()
+        traitlets_config.default_file = "/nonexistent/template.py"
+
+        from marimo_jupyter_extension import config as config_mod
+
+        server_app = MagicMock()
+        with patch(
+            "marimo_jupyter_extension.config.get_config",
+            return_value=config_mod.get_config(traitlets_config),
+        ):
+            import pytest
+
+            with pytest.raises(FileNotFoundError):
+                _load_default_file(server_app)
+
+
 class TestLoadServerExtension:
     """Test suite for _load_jupyter_server_extension."""
 
@@ -306,3 +474,32 @@ class TestLoadServerExtension:
         page_config = server_app.web_app.settings["page_config_data"]
         assert page_config["existing"] == "value"
         assert page_config["marimoVersion"] == "0.23.1"
+
+    def test_aborts_handler_registration_when_default_file_missing(
+        self, clean_env
+    ):
+        """The template read must run *before* add_handlers. If the
+        operator points default_file at a missing path, the extension
+        load aborts with FileNotFoundError and no routes get
+        registered — preventing CreateStubHandler from silently falling
+        back to default boilerplate."""
+        import pytest
+
+        from marimo_jupyter_extension import config as config_mod
+        from marimo_jupyter_extension.config import MarimoProxyConfig
+        from marimo_jupyter_extension.handlers import (
+            _load_jupyter_server_extension,
+        )
+
+        traitlets_config = MarimoProxyConfig()
+        traitlets_config.default_file = "/nonexistent/template.py"
+
+        server_app = self._make_server_app()
+        with patch(
+            "marimo_jupyter_extension.config.get_config",
+            return_value=config_mod.get_config(traitlets_config),
+        ):
+            with pytest.raises(FileNotFoundError):
+                _load_jupyter_server_extension(server_app)
+
+        server_app.web_app.add_handlers.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `MarimoProxyConfig.default_file`, an optional traitlets config that points at a template file. When set, the file's contents become the body of every newly created notebook via `POST /marimo-tools/create-stub`. When unset, the existing built-in boilerplate is emitted, so existing deployments see no change.

## Motivation

In team deployments, every "New Marimo Notebook" produces the same eight-line stub and each user re-types the same imports. A configurable template lets a deployment surface common setup (an `app.setup` block, project imports, a pinned `__generated_with`) so new notebooks land ready to use.

## How it works

Configure in `jupyter_server_config.py`:

```python
c.MarimoProxyConfig.default_file = "/path/to/template.py"
```

- The file is read once at extension load and cached on `web_app.settings`; per-request stub creation never touches disk.
- Contents are emitted verbatim. `__generated_with` is not substituted, so the template's pin (if any) wins.
- A missing path raises `FileNotFoundError` at load time, jupyter-server logs the traceback, and the extension is skipped. `POST /marimo-tools/create-stub` returns 404 until the path is fixed and the server is restarted. This was preferred over silent fallback to the default boilerplate, which would mask the misconfiguration.
- Template changes require restarting Jupyter Server.

The cache-at-load design (rather than reading on every request) is deliberate. The boot log captures exactly what shipped, and the on-disk file cannot be edited to change what users get mid-session.

## Files changed

- `marimo_jupyter_extension/config.py` — new `default_file` trait + `Config` plumbing.
- `marimo_jupyter_extension/handlers.py` — `_load_default_file()` runs before `add_handlers` in `_load_jupyter_server_extension`; `CreateStubHandler.post` consults `web_app.settings[_DEFAULT_FILE_SETTING]`.
- `tests/test_config.py`, `tests/test_handlers.py` — trait defaults, stub composition with and without a template, PEP 723 header interaction, `_load_default_file` read/none/missing, and the load-ordering invariant (no handler registration when the template is missing).
- `docs/configuration.md` — config reference + worked template example.

## Test plan

- [x] `pytest` — 103 passing locally.
- [x] `ruff format --check .` and `ruff check .` clean.
- [x] End-to-end smoke against a local JupyterHub image: template loaded, `POST /marimo-tools/create-stub` returned the configured body, missing-path produced a clear boot-log error.