### PR TITLE
fix: bump @jupyterlab/builder to 4.5.8 (unblock CI) + marimo 0.23.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Quick Start
 
 ```bash
-uv pip install 'marimo[sandbox]>=0.23.4' marimo-jupyter-extension
+uv pip install 'marimo[sandbox]>=0.23.9' marimo-jupyter-extension
 ```
 
 Launch JupyterLab and click the marimo icon in the launcher, or use the sidebar panel.
@@ -70,7 +70,7 @@ See [Installation Guide](https://marimo-team.github.io/marimo-jupyter-extension/
 ### Single Environment
 
 ```bash
-uv pip install 'marimo[sandbox]>=0.23.4' marimo-jupyter-extension
+uv pip install 'marimo[sandbox]>=0.23.9' marimo-jupyter-extension
 ```
 
 ### Multiple Environments (JupyterHub)
@@ -146,7 +146,7 @@ See [Troubleshooting Guide](https://marimo-team.github.io/marimo-jupyter-extensi
 | marimo icon missing | Install `marimo-jupyter-extension` in Jupyter's environment |
 | marimo fails to launch | Ensure marimo is in PATH or configure `MarimoProxyConfig.marimo_path` |
 | Modules not found | Install marimo in the same environment as your packages |
-| Sandbox features not working | Upgrade to `marimo[sandbox]>=0.23.4` |
+| Sandbox features not working | Upgrade to `marimo[sandbox]>=0.23.9` |
 
 ## Community
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ On JupyterHub deployments, this leverages existing authentication and spawning i
 ## Quick Start
 
 ```bash
-pip install 'marimo>=0.23.4' marimo-jupyter-extension
+pip install 'marimo>=0.23.9' marimo-jupyter-extension
 ```
 
 Launch JupyterLab and click the marimo icon in the launcher.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,14 +3,14 @@
 ## Requirements
 
 - Python 3.10+
-- marimo >= 0.23.4
+- marimo >= 0.23.9
 
 ## Basic Installation
 
 `marimo-jupyter-extension` requires marimo but does not declare it as a dependency, allowing flexible installation scenarios.
 
 ```bash
-pip install 'marimo>=0.23.4' marimo-jupyter-extension
+pip install 'marimo>=0.23.9' marimo-jupyter-extension
 ```
 
 Or with uv:
@@ -28,7 +28,7 @@ FROM quay.io/jupyterhub/jupyterhub:latest
 RUN cd /srv/jupyterhub && jupyterhub --generate-config && \
     echo "c.JupyterHub.authenticator_class = 'dummy'" >> jupyterhub_config.py && \
     echo "c.DummyAuthenticator.password = 'demo'" >> jupyterhub_config.py && \
-    pip install --no-cache-dir notebook 'marimo>=0.23.4' marimo-jupyter-extension
+    pip install --no-cache-dir notebook 'marimo>=0.23.9' marimo-jupyter-extension
 RUN useradd -ms /bin/bash demo
 ```
 
@@ -56,7 +56,7 @@ RUN curl -fsSL https://github.com/conda-forge/miniforge/releases/latest/download
     bash /root/miniforge.sh -b -p /opt/conda && rm /root/miniforge.sh
 
 # marimo in conda environment (user packages available)
-RUN /opt/conda/bin/pip install --no-cache-dir 'marimo>=0.23.4'
+RUN /opt/conda/bin/pip install --no-cache-dir 'marimo>=0.23.9'
 
 # marimo-jupyter-extension in Jupyter's environment
 RUN /usr/bin/pip install --no-cache-dir marimo-jupyter-extension

--- a/docs/jupyterhub.md
+++ b/docs/jupyterhub.md
@@ -64,7 +64,7 @@ dependencies = [
     "notebook>=7.5.0",
     "oauthenticator>=17.3.0",
     "jupyterhub-systemdspawner>=1.0.2",
-    "marimo>=0.23.4",
+    "marimo>=0.23.9",
     "marimo-jupyter-extension>=0.1.0",
 ]
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,10 +92,10 @@ Run `marimo config show` in a JupyterHub terminal to verify marimo's effective c
 
 **Cause**: marimo version is too old.
 
-**Solution**: Upgrade to marimo 0.23.4 or newer:
+**Solution**: Upgrade to marimo 0.23.9 or newer:
 
 ```bash
-pip install 'marimo>=0.23.4'
+pip install 'marimo>=0.23.9'
 ```
 
 ### JupyterHub Issues

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@jupyterlab/builder": "4.5.7",
+    "@jupyterlab/builder": "4.5.8",
     "@types/node": "24.12.3",
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",

--- a/labextension/pnpm-lock.yaml
+++ b/labextension/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
       '@jupyterlab/builder':
-        specifier: 4.5.7
-        version: 4.5.7
+        specifier: 4.5.8
+        version: 4.5.8
       '@types/node':
         specifier: 24.12.3
         version: 24.12.3
@@ -309,8 +309,8 @@ packages:
   '@jupyterlab/apputils@4.6.7':
     resolution: {integrity: sha512-PpGhgq8mxVL4g1lA5mw9QQ5bOBNT5lHan3KPhEJsSQ6rW2K7GMC/fPO8ahhPgYZ3MzCicLNxJkFA/dDnkBqs3w==}
 
-  '@jupyterlab/builder@4.5.7':
-    resolution: {integrity: sha512-lJnw/mXpo7T5QmFZm5IyD7gEEyi9lHIXKRPtWYU4TsJ4V7JIYh7FeTi9gMzZGuG3ezG/IWIKk3/KX/vEKeBE/g==}
+  '@jupyterlab/builder@4.5.8':
+    resolution: {integrity: sha512-P6NjJ6GP2upT0f5Hbpe5tD9EQ3prwj2Y9QBVAguP+vLtvXWGxkQAAHgbGYZJCFRnUnAm0zE7Ypm9zrHvmn962g==}
     hasBin: true
 
   '@jupyterlab/codeeditor@4.5.7':
@@ -606,9 +606,6 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
   '@types/node@24.12.3':
     resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
 
@@ -618,17 +615,11 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
-  '@types/source-list-map@0.1.6':
-    resolution: {integrity: sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==}
-
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/webpack-sources@0.1.12':
-    resolution: {integrity: sha512-+vRVqE3LzMLLVPgZHUeI8k1YmvgEky+MOir5fQhKvFxpB8uZ0CFnGqxkRAmf8jvNhUBQzhuGZpIMNWZDeEyDIA==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1832,8 +1823,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  license-webpack-plugin@2.3.21:
-    resolution: {integrity: sha512-rVaYU9TddZN3ao8M/0PrRSCdTp2EW6VQymlgsuScld1vef0Ou7fALx3ePe83KLP3xAEDcPK5fkqUVqGBnbz1zQ==}
+  license-webpack-plugin@4.0.2:
+    resolution: {integrity: sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==}
     peerDependencies:
       webpack: '*'
     peerDependenciesMeta:
@@ -2467,9 +2458,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  source-list-map@2.0.1:
-    resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2852,9 +2840,6 @@ packages:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
     engines: {node: '>=10.0.0'}
 
-  webpack-sources@1.4.3:
-    resolution: {integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==}
-
   webpack-sources@3.4.1:
     resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
     engines: {node: '>=10.13.0'}
@@ -3185,14 +3170,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3206,7 +3191,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -3309,7 +3294,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@jupyterlab/builder@4.5.7':
+  '@jupyterlab/builder@4.5.8':
     dependencies:
       '@lumino/algorithm': 2.0.4
       '@lumino/application': 2.4.8
@@ -3329,7 +3314,7 @@ snapshots:
       duplicate-package-checker-webpack-plugin: 3.0.0
       fs-extra: 10.1.0
       glob: 7.1.7
-      license-webpack-plugin: 2.3.21(webpack@5.106.2)
+      license-webpack-plugin: 4.0.2(webpack@5.106.2)
       mini-css-extract-plugin: 2.10.2(webpack@5.106.2)
       mini-svg-data-uri: 1.4.4
       path-browserify: 1.0.1
@@ -3341,6 +3326,7 @@ snapshots:
       webpack: 5.106.2(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.106.2)
       webpack-merge: 5.10.0
+      webpack-sources: 3.4.1
       worker-loader: 3.0.8(webpack@5.106.2)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -3835,15 +3821,11 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
-
-  '@types/node@24.12.2':
-    dependencies:
-      undici-types: 7.16.0
 
   '@types/node@24.12.3':
     dependencies:
@@ -3856,17 +3838,9 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@types/source-list-map@0.1.6': {}
-
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/webpack-sources@0.1.12':
-    dependencies:
-      '@types/node': 24.12.2
-      '@types/source-list-map': 0.1.6
-      source-map: 0.6.1
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -5161,7 +5135,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -5185,13 +5159,13 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       jest-util: 29.7.0
 
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5199,7 +5173,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.12.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -5298,10 +5272,9 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
-  license-webpack-plugin@2.3.21(webpack@5.106.2):
+  license-webpack-plugin@4.0.2(webpack@5.106.2):
     dependencies:
-      '@types/webpack-sources': 0.1.12
-      webpack-sources: 1.4.3
+      webpack-sources: 3.4.1
     optionalDependencies:
       webpack: 5.106.2(webpack-cli@5.1.4)
 
@@ -5936,8 +5909,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  source-list-map@2.0.1: {}
-
   source-map-js@1.2.1: {}
 
   source-map-loader@1.0.2(webpack@5.106.2):
@@ -6295,11 +6266,6 @@ snapshots:
       clone-deep: 4.0.1
       flat: 5.0.2
       wildcard: 2.0.1
-
-  webpack-sources@1.4.3:
-    dependencies:
-      source-list-map: 2.0.1
-      source-map: 0.6.1
 
   webpack-sources@3.4.1: {}
 

--- a/marimo_jupyter_extension/executable.py
+++ b/marimo_jupyter_extension/executable.py
@@ -7,7 +7,7 @@ from .config import Config
 
 # Single source of truth for the marimo version this extension targets.
 # scripts/bump-marimo.sh updates this literal alongside the README docs.
-MARIMO_VERSION = "0.23.4"
+MARIMO_VERSION = "0.23.9"
 
 COMMON_LOCATIONS = [
     "~/.local/bin/marimo",


### PR DESCRIPTION
## Why

JupyterLab `4.5.8` was release now requires a devDependency on `@jupyterlab/builder@^4.5.8`.
Because CI installs the latest JupyterLab via `uv sync`, every editable install fails the labextension build,

+ marimo bump to 0.23.9