### PR TITLE
Replace clipboard writeText with Clipboard.copyToSystem

### DIFF
--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -4,6 +4,7 @@ import {
   type JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
 import {
+  Clipboard,
   Dialog,
   InputDialog,
   Notification,
@@ -580,7 +581,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           appUrl = `${baseUrl}?file=${encodeURIComponent(filePath)}&show-chrome=false&view-as=present`;
         }
 
-        await navigator.clipboard.writeText(appUrl);
+        Clipboard.copyToSystem(appUrl);
         Notification.success('App link copied to clipboard');
       },
     });


### PR DESCRIPTION
On untrusted deployments (essentially in HTTP and not localhost nor 127.0.01), `navigator.clipboard` is `undefined`.
A clic on "Copy App Link" produces this error below :
<img width="919" height="133" alt="image" src="https://github.com/user-attachments/assets/f8a789fb-8eaf-4081-91ab-0bf2db22fd14" />

The use of `Clipboard.copyToSystem` from `@jupyterlab/apputils` fixes this.