### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,63 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      # Node toolchain (mirrors lint.yml lint-typescript)
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          package_json_file: labextension/package.json
+
+      - name: Install dependencies
+        working-directory: labextension
+        run: pnpm install --frozen-lockfile
+
+      # Python toolchain (mirrors lint.yml lint-python)
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # Fixers: mutating variants of the lint.yml checks, each `|| true`
+      - name: Format (Biome)
+        working-directory: labextension
+        run: pnpm run format || true
+
+      - name: Lint fix (Biome)
+        working-directory: labextension
+        run: pnpm run lint:biome || true
+
+      - name: Lint fix (ESLint)
+        working-directory: labextension
+        run: pnpm run lint:eslint || true
+
+      - name: Ruff format (Python)
+        run: uvx ruff format . || true
+
+      - name: Ruff check (Python)
+        run: uvx ruff check --fix . || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that automatically formats/lints PRs and pushes the fixes back, so contributors don't get red CI over mechanical issues that a tool can fix. The [autofix.ci](https://autofix.ci) GitHub App is already installed org-wide (confirmed by the org admin today), so no per-repo setup is needed.

The workflow `name` is exactly `autofix.ci` — the service identifies the workflow by name for security, and the `autofix-ci/action` step runs **last**, after all fixers.

## Fixers (mutating variants of `.github/workflows/lint.yml`)

Toolchain setup mirrors the existing `lint.yml` (same actions + SHA pins, Node 24 + pnpm via `package_json_file: labextension/package.json`, uv + Python 3.12). Each fixer is guarded with `|| true`:

- `pnpm run format` — Biome format (mirrors `format:check`)
- `pnpm run lint:biome` — Biome lint `--write` (part of `lint:check`)
- `pnpm run lint:eslint` — `eslint src --fix` (part of `lint:check`)
- `uvx ruff format .` (mirrors `uvx ruff format --check .`)
- `uvx ruff check --fix .` (mirrors `uvx ruff check .`)

Note: the top-level `pnpm run lint` script references `run-s2`, which is not a real binary (npm-run-all2 provides `run-s`), so it currently fails. CI uses `lint:check`, not `lint`, so this is pre-existing and out of scope here — the workflow calls the `lint:biome`/`lint:eslint` sub-scripts directly instead.

## Verification

Cloned, installed, and ran every fixer locally against `main` — all produced **no diff** on the current tree, so no mechanical fixes are bundled into this PR. Workflow validated with `actionlint` (clean).

Part of the marimo-team engineering-excellence initiative.
