### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ __pycache__/
 # C extensions
 *.so
 
-CLAUDE.md
-AGENTS.md
 __marimo__/
 
 .yarn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# marimo-jupyter-extension
+
+Jupyter/JupyterLab extension that proxies marimo (server proxy + prebuilt labextension). Published to PyPI as `marimo-jupyter-extension`; the frontend npm package is `@marimo-team/jupyter-extension`.
+
+## Development
+
+Dual toolchain. TypeScript lives in `labextension/` (pnpm); the Python server extension is at the repo root (uv + ruff).
+
+```bash
+# Frontend — run inside labextension/
+pnpm install
+pnpm run test          # vitest
+pnpm run typecheck     # tsc --noEmit
+pnpm run lint:check    # biome + eslint (no writes)
+pnpm run lint:biome    # biome autofix   (lint:eslint for eslint --fix)
+pnpm run format        # biome format --write   (format:check to verify)
+pnpm run build         # dev build (build:prod for release)
+
+# Python — run at repo root
+uv sync
+uv run pytest
+uvx ruff format . && uvx ruff check .
+```
+
+- Do NOT run `pnpm run lint` — it invokes a nonexistent `run-s2` binary and fails; use `lint:check` / `lint:biome` / `lint:eslint` instead.
+- Frontend commands must run from `labextension/`; pnpm is pinned via `packageManager` there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Adopts the marimo-team convention where AGENTS.md is the canonical agent-context doc and CLAUDE.md is a symlink to it (`ln -s AGENTS.md CLAUDE.md`), so every agent reads one source of truth. The doc is deliberately minimal — a one-line overview plus verified development commands — because it loads into every agent context and fewer tokens is better. Part of the marimo-team engineering-excellence initiative to give agents consistent, low-overhead repo context.

Note: `.gitignore` previously ignored AGENTS.md/CLAUDE.md; removed those two lines so the doc can be tracked (`.claude/` stays ignored).