### PR TITLE
feat: Allow marimo tabs to be restored on reload (#126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ When creating a new notebook, select from available Python environments. The ext
 - **Edit with marimo**: Right-click any `.py` or `_mo.py` file to open it in the marimo editor
 - **Convert to marimo**: Right-click any `.ipynb` file to convert it to marimo format
 
+### Tab Restoration
+
+Marimo notebooks that have been saved to a file are reopened when the JupyterLab page reloads, the same way `.ipynb` tabs are.
+
 ## Installation
 
 See [Installation Guide](https://marimo-team.github.io/marimo-jupyter-extension/installation/) for detailed setup instructions.

--- a/labextension/src/iframe-widget.ts
+++ b/labextension/src/iframe-widget.ts
@@ -212,39 +212,30 @@ export function createMarimoIFrame(
 /**
  * Create a marimo widget that embeds the editor in an iframe.
  * Uses createMarimoIFrame internally for consistent IFrame creation.
+ *
+ * Only for notebooks with no file behind them yet; file-backed notebooks open
+ * through MarimoWidgetFactory.
  */
 export function createMarimoWidget(
   baseUrl: string,
-  options: { filePath?: string; label?: string } = {},
+  options: { label?: string } = {},
 ): MainAreaWidget<IFrame> {
-  const { filePath, label } = options;
-
   // Use centralized IFrame creation
   const {
     iframe: content,
     url: finalUrl,
     initId,
-  } = createMarimoIFrame(baseUrl, { filePath });
+  } = createMarimoIFrame(baseUrl);
 
   const widget = new MainAreaWidget({ content });
   widget.id = `marimo-${UUID.uuid4()}`;
-
-  if (label) {
-    widget.title.label = label;
-  } else if (filePath) {
-    const parts = filePath.split('/');
-    widget.title.label = parts[parts.length - 1] || 'marimo';
-  } else {
-    widget.title.label = 'marimo';
-  }
-
+  widget.title.label = options.label ?? 'marimo';
   widget.title.closable = true;
   widget.title.icon = leafIcon;
-  widget.title.caption = filePath ? `marimo: ${filePath}` : 'marimo Editor';
+  widget.title.caption = 'marimo Editor';
 
-  // Track widgets for disconnection handling
+  // Track by initializationId for disconnection handling
   if (initId) {
-    // New notebook - track by initializationId
     const widgetId = `marimo-widget-${UUID.uuid4()}`;
     widgetsByInitId.set(initId, {
       widget,
@@ -257,9 +248,6 @@ export function createMarimoWidget(
       widgetsByInitId.delete(initId);
     });
     initializeMessageListener();
-  } else if (filePath) {
-    // File-based notebook - track by filePath
-    registerWidgetForTracking(widget, filePath, finalUrl);
   }
 
   return widget;

--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -8,6 +8,7 @@ import {
   Dialog,
   InputDialog,
   Notification,
+  WidgetTracker,
   showDialog,
   showErrorMessage,
 } from '@jupyterlab/apputils';
@@ -35,7 +36,11 @@ import {
   refreshWidgetByFilePath,
 } from './iframe-widget';
 import { MarimoSidebar } from './sidebar';
-import { FACTORY_NAME, MarimoWidgetFactory } from './widget-factory';
+import {
+  FACTORY_NAME,
+  type MarimoDocWidget,
+  MarimoWidgetFactory,
+} from './widget-factory';
 
 import '../style/base.css';
 
@@ -50,6 +55,12 @@ const CommandIDs = {
   copyAppLink: 'marimo:copy-app-link',
   newNotebookInFolder: 'marimo:new-notebook-in-folder',
 } as const;
+
+/**
+ * The JupyterLab command that opens a path with a given document factory.
+ * Used both to open marimo notebooks and to reopen them on layout restore.
+ */
+const DOCUMENT_OPEN_COMMAND = 'docmanager:open';
 
 /**
  * Get the base URL for the Marimo proxy.
@@ -98,6 +109,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     // Register the Marimo file type for _mo.py files
     app.docRegistry.addFileType(marimoFileType);
+
+    /**
+     * Open a file in the marimo editor via the document registry.
+     */
+    async function openMarimoDocument(filePath: string): Promise<void> {
+      await commands.execute(DOCUMENT_OPEN_COMMAND, {
+        path: filePath,
+        factory: FACTORY_NAME,
+      });
+    }
+
+    /**
+     * Open the marimo editor on a notebook that has no file yet.
+     */
+    function openScratchNotebook(): void {
+      const widget = createMarimoWidget(marimoBaseUrl, {
+        label: 'New Notebook',
+      });
+      shell.add(widget, 'main');
+      shell.activateById(widget.id);
+    }
 
     // Shared helper: prompt for filename and create a notebook stub in the given directory
     async function createNotebookAt(
@@ -209,9 +241,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           continue;
         }
 
-        const widget = createMarimoWidget(marimoBaseUrl, { filePath });
-        shell.add(widget, 'main');
-        shell.activateById(widget.id);
+        await openMarimoDocument(filePath);
         done = true;
       }
     }
@@ -225,14 +255,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
         const path = getSelectedFilePath(fileBrowserFactory);
         return path !== null && (isPythonFile(path) || isMarimoFile(path));
       },
-      execute: () => {
+      execute: async () => {
         const filePath = getSelectedFilePath(fileBrowserFactory);
         if (!filePath) {
           return;
         }
-        const widget = createMarimoWidget(marimoBaseUrl, { filePath });
-        shell.add(widget, 'main');
-        shell.activateById(widget.id);
+        await openMarimoDocument(filePath);
       },
     });
 
@@ -294,11 +322,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           }
 
           // Open the converted file in marimo
-          const widget = createMarimoWidget(marimoBaseUrl, {
-            filePath: outputPath,
-          });
-          shell.add(widget, 'main');
-          shell.activateById(widget.id);
+          await openMarimoDocument(outputPath);
         } catch (error) {
           showErrorMessage(
             'Conversion failed',
@@ -342,11 +366,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
             if (cwd) {
               await createNotebookAt(cwd, undefined);
             } else {
-              const widget = createMarimoWidget(marimoBaseUrl, {
-                label: 'New Notebook',
-              });
-              shell.add(widget, 'main');
-              shell.activateById(widget.id);
+              openScratchNotebook();
             }
             return;
           }
@@ -387,11 +407,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
             if (cwd) {
               await createNotebookAt(cwd, undefined);
             } else {
-              const widget = createMarimoWidget(marimoBaseUrl, {
-                label: 'New Notebook',
-              });
-              shell.add(widget, 'main');
-              shell.activateById(widget.id);
+              openScratchNotebook();
             }
             return;
           }
@@ -421,22 +437,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
           // If Default selected and at root, open marimo directly
           if (!venv && !cwd) {
-            const widget = createMarimoWidget(marimoBaseUrl, {
-              label: 'New Notebook',
-            });
-            shell.add(widget, 'main');
-            shell.activateById(widget.id);
+            openScratchNotebook();
             return;
           }
 
           await createNotebookAt(cwd, venv);
         } catch {
           // Fall back to opening marimo directly on any error
-          const widget = createMarimoWidget(marimoBaseUrl, {
-            label: 'New Notebook',
-          });
-          shell.add(widget, 'main');
-          shell.activateById(widget.id);
+          openScratchNotebook();
         }
       },
     });
@@ -651,6 +659,28 @@ const plugin: JupyterFrontEndPlugin<void> = {
       defaultFor: ['marimo'], // Default for _mo.py files, "Open With" for .py files
     });
     app.docRegistry.addWidgetFactory(widgetFactory);
+
+    // Track the tabs the factory opens. Without a tracker registered with the
+    // layout restorer, JupyterLab has no record of these widgets and drops
+    // them on reload, while .ipynb tabs (whose plugin does register one) come
+    // back.
+    const documentTracker = new WidgetTracker<MarimoDocWidget>({
+      namespace: 'marimo-documents',
+    });
+    widgetFactory.widgetCreated.connect((_factory, widget) => {
+      void documentTracker.add(widget);
+    });
+
+    if (restorer) {
+      void restorer.restore(documentTracker, {
+        command: DOCUMENT_OPEN_COMMAND,
+        args: (widget) => ({
+          path: widget.context.path,
+          factory: FACTORY_NAME,
+        }),
+        name: (widget) => widget.context.path,
+      });
+    }
   },
 };
 


### PR DESCRIPTION
Register saved marimo notebooks with a WidgetTracker that will restore them when the JupyterLab layout is reloaded. File-backed notebooks are routed through the document registry rather than a temporary widget.